### PR TITLE
Windows now uses Uvicorn

### DIFF
--- a/langflow/backend/langflow_backend/__main__.py
+++ b/langflow/backend/langflow_backend/__main__.py
@@ -36,8 +36,10 @@ def serve(
         "timeout": timeout,
     }
 
-    if platform.system() == "Darwin":
-        # Run using uvicorn on MacOS
+    if platform.system() in ["Darwin", "Windows"]:
+        # Run using uvicorn on MacOS and Windows
+        # Windows doesn't support gunicorn
+        # MacOS requires a env variable to be set to use gunicorn
         import uvicorn
 
         uvicorn.run(app, host=host, port=port, log_level="info")


### PR DESCRIPTION
Gunicorn is a linux/mac thing and can't run on Windows. This should fix it.

#25