### PR TITLE
Changed frontend's default backendUrl to `window.location.hostname`

### DIFF
--- a/langflow/frontend/src/controllers/NodesServices/index.ts
+++ b/langflow/frontend/src/controllers/NodesServices/index.ts
@@ -1,7 +1,7 @@
 import { APIObjectType, sendAllProps } from '../../types/api/index';
 import axios, { AxiosResponse } from "axios";
 
-const backendUrl = process.env.BACKEND || "http://localhost:5003";
+const backendUrl = process.env.BACKEND || `http://${window.location.hostname}:5003`;
 
 export async function getAll():Promise<AxiosResponse<APIObjectType>> {
     return await axios.get(`${backendUrl}/all`);


### PR DESCRIPTION
Currently, when running langflow with the `--host` option and accessing langflow from another machine, the frontend still tries to ping `http://localhost:5003`

This PR replaces `localhost` with `window.location.hostname` so the frontend works correctly in the aforementioned scenario.