### PR TITLE
Add contrib link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ flow("Hey, have you heard of LangFlow?")
 
 ## 👋 Contributing
 
-We welcome contributions from developers of all levels to our open-source project on GitHub. If you'd like to contribute, please check our contributing guidelines and help make LangFlow more accessible.
+We welcome contributions from developers of all levels to our open-source project on GitHub. If you'd like to contribute, please check our [contributing guidelines](./CONTRIBUTING.md) and help make LangFlow more accessible.
 
 
 [![Star History Chart](https://api.star-history.com/svg?repos=logspace-ai/langflow&type=Timeline)](https://star-history.com/#logspace-ai/langflow&Date)


### PR DESCRIPTION
When I was trying to get started with LangFlow I didn't realize the local development setup was in the contributing documentation. I though adding a link in the readme would be a good place to start, but maybe in the future we can bring the local development setup instructions into the readme.