### PR TITLE
The installation of the new version of langflow has failed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ lxml = "^4.9.2"
 pysrt = "^1.1.2"
 fake-useragent = "^1.1.3"
 docstring-parser = "^0.15"
-psycopg2 = "^2.9.6"
+psycopg2-binary = "^2.9.6"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.1.0"


### PR DESCRIPTION
The installation package of psycopg2 failed to be installed using pip, which caused the failure of installing the new version of langflow. Therefore, psycopg2-binary was used as a replacement.