### PR TITLE
feat: add demo devcontainer

### DIFF
--- a/.devcontainer/demo/README.md
+++ b/.devcontainer/demo/README.md
@@ -1,0 +1,15 @@
+# LangFlow Demo Codespace Readme
+
+These instructions will walk you through the process of running a LangFlow demo via GitHub Codespaces.
+
+## Setup
+
+### Create a Codespace in GitHub
+
+To setup the demo, simply navigate to the Langflow repo, click the "+" button, and select "Create new Codespace". This will automatically create a new codespace in your browser, which you can use for the demo.
+
+### Wait for everything to install
+
+After the codespace is opened, you should see a new Terminal window in VS Code where langflow is installed. Once the install completes, `langflow` will launch the webserver and your application will be available via devcontainer port. 
+
+Note: VS Code should prompt you with a button to push once the port is available.

--- a/.devcontainer/demo/devcontainer.json
+++ b/.devcontainer/demo/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/universal
+{
+	"name": "LangChain Demo Container",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:3.10",
+	"features": {
+		"ghcr.io/devcontainers/features/aws-cli:1": {},
+		"ghcr.io/devcontainers/features/docker-in-docker": {},
+		"ghcr.io/devcontainers/features/node": {}
+	},
+	"customizations": {
+		"vscode": {"extensions": [
+				"actboy168.tasks",
+				"GitHub.copilot",
+				"ms-python.python",
+				"eamodio.gitlens"
+			]}
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pipx install 'langflow>=0.0.33' && langflow --host 0.0.0.0",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/demo/devcontainer.json
+++ b/.devcontainer/demo/devcontainer.json
@@ -10,26 +10,23 @@
 		"ghcr.io/devcontainers/features/node": {}
 	},
 	"customizations": {
-		"vscode": {"extensions": [
+		"vscode": {
+			"extensions": [
 				"actboy168.tasks",
 				"GitHub.copilot",
 				"ms-python.python",
 				"eamodio.gitlens"
-			]}
+			]
+		}
 	},
-
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pipx install 'langflow>=0.0.33' && langflow --host 0.0.0.0",
-
+	"postCreateCommand": "pipx install 'langflow>=0.0.33' && langflow --host 0.0.0.0"
 	// Configure tool-specific properties.
 	// "customizations": {},
-
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,12 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/universal
 {
-	"name": "Default Linux Universal",
+	"name": "LangChain Dev Container",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/universal:2-linux",
 	"features": {
-		"ghcr.io/devcontainers/features/aws-cli:1": {}
+		"ghcr.io/devcontainers/features/aws-cli:1": {},
+		"ghcr.io/devcontainers/features/docker-in-docker": {}
 	},
 	"customizations": {
 		"vscode": {"extensions": [
@@ -15,7 +16,7 @@
 				"sourcery.sourcery",
 				"eamodio.gitlens"
 			]}
-	}
+	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
@@ -24,7 +25,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "uname -a",
+	"postCreateCommand": "poetry install"
 
 	// Configure tool-specific properties.
 	// "customizations": {},


### PR DESCRIPTION
Partially resolves #196 (No demo workflow yet, but UI launches successfully.)

**Important:**

1. I've tested this locally in VS Code successfully - the `postCreateCommand` performs _both_ the install of `langflow` from pip (via pipx) and also the launching of `langflow` UI. VS Code also helpfully told me when the new port had been opened and I could simply click the button to open the site in a browser tap.
2. Page functions in the UI seem to be working great.
3. I have **not** yet tested this in Codespaces, but something other than the default 2-CPU image might be warranted here.
4. The new README could use some more work, admittedly, but as of now at least, it tells the audience what to expect from the container.

Can be tested with this link: [Create new codespace](https://github.com/codespaces/new?hide_repo_select=true&repo=632705010&branch=aj%2Fdemo-devcontainer&devcontainer_path=.devcontainer/demo/devcontainer.json) 

You have to manually select the branch and also choose second option in the list of Devcontainer options:

> <img width="912" alt="image" src="https://user-images.githubusercontent.com/18150651/234445850-19e9d7f8-d2ef-4a0d-b7b7-194d432668ea.png">
