### PR TITLE
Copy Paste, Undo and Redo implemented

### DIFF
--- a/src/frontend/src/pages/FlowPage/hooks/useUndoRedo.ts
+++ b/src/frontend/src/pages/FlowPage/hooks/useUndoRedo.ts
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Edge, Node, useReactFlow } from 'reactflow';
+
+type UseUndoRedoOptions = {
+  maxHistorySize: number;
+  enableShortcuts: boolean;
+};
+
+type UseUndoRedo = (options?: UseUndoRedoOptions) => {
+  undo: () => void;
+  redo: () => void;
+  takeSnapshot: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+};
+
+type HistoryItem = {
+  nodes: Node[];
+  edges: Edge[];
+};
+
+const defaultOptions: UseUndoRedoOptions = {
+  maxHistorySize: 100,
+  enableShortcuts: true,
+};
+
+// https://redux.js.org/usage/implementing-undo-history
+export const useUndoRedo: UseUndoRedo = ({
+  maxHistorySize = defaultOptions.maxHistorySize,
+  enableShortcuts = defaultOptions.enableShortcuts,
+} = defaultOptions) => {
+  // the past and future arrays store the states that we can jump to
+  const [past, setPast] = useState<HistoryItem[]>([]);
+  const [future, setFuture] = useState<HistoryItem[]>([]);
+
+  const { setNodes, setEdges, getNodes, getEdges } = useReactFlow();
+
+  const takeSnapshot = useCallback(() => {
+    // push the current graph to the past state
+    setPast((past) => [
+      ...past.slice(past.length - maxHistorySize + 1, past.length),
+      { nodes: getNodes(), edges: getEdges() },
+    ]);
+
+    // whenever we take a new snapshot, the redo operations need to be cleared to avoid state mismatches
+    setFuture([]);
+  }, [getNodes, getEdges, maxHistorySize]);
+
+  const undo = useCallback(() => {
+    // get the last state that we want to go back to
+    const pastState = past[past.length - 1];
+
+    if (pastState) {
+      // first we remove the state from the history
+      setPast((past) => past.slice(0, past.length - 1));
+      // we store the current graph for the redo operation
+      setFuture((future) => [...future, { nodes: getNodes(), edges: getEdges() }]);
+      // now we can set the graph to the past state
+      setNodes(pastState.nodes);
+      setEdges(pastState.edges);
+    }
+  }, [setNodes, setEdges, getNodes, getEdges, past]);
+
+  const redo = useCallback(() => {
+    const futureState = future[future.length - 1];
+
+    if (futureState) {
+      setFuture((future) => future.slice(0, future.length - 1));
+      setPast((past) => [...past, { nodes: getNodes(), edges: getEdges() }]);
+      setNodes(futureState.nodes);
+      setEdges(futureState.edges);
+    }
+  }, [setNodes, setEdges, getNodes, getEdges, future]);
+
+  useEffect(() => {
+    // this effect is used to attach the global event handlers
+    if (!enableShortcuts) {
+      return;
+    }
+
+    const keyDownHandler = (event: KeyboardEvent) => {
+      if (event.key === 'z' && (event.ctrlKey || event.metaKey) && event.shiftKey) {
+        redo();
+      } else if (event.key === 'z' && (event.ctrlKey || event.metaKey)) {
+        undo();
+      }
+    };
+
+    document.addEventListener('keydown', keyDownHandler);
+
+    return () => {
+      document.removeEventListener('keydown', keyDownHandler);
+    };
+  }, [undo, redo, enableShortcuts]);
+
+  return {
+    undo,
+    redo,
+    takeSnapshot,
+    canUndo: !past.length,
+    canRedo: !future.length,
+  };
+};
+
+export default useUndoRedo;

--- a/src/frontend/src/pages/FlowPage/hooks/useUndoRedo.ts
+++ b/src/frontend/src/pages/FlowPage/hooks/useUndoRedo.ts
@@ -81,6 +81,10 @@ export const useUndoRedo: UseUndoRedo = ({
     const keyDownHandler = (event: KeyboardEvent) => {
       if (event.key === 'z' && (event.ctrlKey || event.metaKey) && event.shiftKey) {
         redo();
+      } 
+      else if (event.key === 'y' && (event.ctrlKey || event.metaKey)) {
+        event.preventDefault(); // prevent the default action
+        redo();
       } else if (event.key === 'z' && (event.ctrlKey || event.metaKey)) {
         undo();
       }
@@ -97,8 +101,8 @@ export const useUndoRedo: UseUndoRedo = ({
     undo,
     redo,
     takeSnapshot,
-    canUndo: !past.length,
-    canRedo: !future.length,
+    canUndo: !!past.length,
+    canRedo: !!future.length,
   };
 };
 

--- a/src/frontend/src/pages/FlowPage/index.tsx
+++ b/src/frontend/src/pages/FlowPage/index.tsx
@@ -45,10 +45,10 @@ export default function FlowPage({ flow }:{flow:FlowType}) {
 
   const { undo, redo, canUndo, canRedo, takeSnapshot } = useUndoRedo();
 
-  const copied = useKeyPress(['Meta+c', 'Strg+c']);
-  const pasted = useKeyPress(['Meta+v', 'Strg+v']);
-  const undoed = useKeyPress(['Meta+z', 'Strg+z']);
-  const redoed = useKeyPress(['Meta+Shift+z', 'Strg+Shift+z']);
+  const copied = useKeyPress(['Meta+c', 'Strg+c', 'Ctrl+c']);
+  const pasted = useKeyPress(['Meta+v', 'Strg+v', 'Ctrl+v']);
+  const undoed = useKeyPress(['Meta+z', 'Strg+z', 'Ctrl+z']);
+  const redoed = useKeyPress(['Meta+Shift+z', 'Strg+Shift+z', 'Ctrl+Shift+z']);
 
   useEffect(() => {
     if(canUndo && undoed){

--- a/src/frontend/src/pages/FlowPage/index.tsx
+++ b/src/frontend/src/pages/FlowPage/index.tsx
@@ -45,20 +45,16 @@ export default function FlowPage({ flow }:{flow:FlowType}) {
 
   const { undo, redo, canUndo, canRedo, takeSnapshot } = useUndoRedo();
 
-  const copied = useKeyPress(['Meta+c', 'Strg+c', 'Ctrl+c']);
-  const pasted = useKeyPress(['Meta+v', 'Strg+v', 'Ctrl+v']);
-  const undoed = useKeyPress(['Meta+z', 'Strg+z', 'Ctrl+z']);
-  const redoed = useKeyPress(['Meta+Shift+z', 'Strg+Shift+z', 'Ctrl+Shift+z']);
-
-  useEffect(() => {
-    if(canUndo && undoed){
-      undo();
+  const onKeyDown = (event : React.KeyboardEvent<HTMLDivElement>) => {
+    if ((event.ctrlKey || event.metaKey) && (event.key === 'c') && lastSelection){
+      event.preventDefault();
+      setLastCopiedSelection(lastSelection);
     }
-    if(canRedo && redoed){
-      redo();
+    if ((event.ctrlKey || event.metaKey) && (event.key === 'v') && lastCopiedSelection){
+      event.preventDefault();
+      paste();
     }
-
-  }, [undoed, redoed])
+  }
 
   const [lastSelection, setLastSelection] = useState(null);
   const [lastCopiedSelection, setLastCopiedSelection] = useState(null);
@@ -73,15 +69,8 @@ export default function FlowPage({ flow }:{flow:FlowType}) {
     onChange: (flow) => {setLastSelection(flow);},
   })
 
-  useEffect(() => {
-    if(copied === true && lastSelection){
-      setLastCopiedSelection(lastSelection);
-    }
-  }, [copied])
-
-  useEffect(() => {
-    if(pasted === true && lastCopiedSelection){
-      let minimumX = Infinity;
+  let paste = () => {
+    let minimumX = Infinity;
       let minimumY = Infinity;
       let idsMap = {};
       lastCopiedSelection.nodes.forEach((n) => {
@@ -135,8 +124,7 @@ export default function FlowPage({ flow }:{flow:FlowType}) {
           addEdge({ source, target, sourceHandle, targetHandle, id, className: "animate-pulse", selected: false }, eds.map((e) => ({...e, selected: false})))
         );
       })
-    }
-  }, [pasted])
+  }
 
 
   const { setExtraComponent, setExtraNavigation } = useContext(locationContext);
@@ -319,6 +307,7 @@ export default function FlowPage({ flow }:{flow:FlowType}) {
 						edges={edges}
 						onNodesChange={onNodesChange}
 						onEdgesChange={onEdgesChangeMod}
+            onKeyDown={(e) => onKeyDown(e)}
 						onConnect={onConnect}
 						onLoad={setReactFlowInstance}
 						onInit={setReactFlowInstance}


### PR DESCRIPTION
## Description

This Pull Request implements four new features in the langflow Workflow project:

- Copy and Paste feature for multiple nodes
- Undo and Redo feature for node actions

### Copy and Paste Feature
The Copy and Paste feature allows users to select multiple nodes by holding down the `Shift` key and dragging the mouse over the nodes, copy them using the `Ctrl+C` keyboard shortcut, and paste them into a different location within the workflow by leaving the mouse pointer at the desired location and pressing `Ctrl+V`.

### Undo and Redo Feature
The Undo and Redo feature allows users to undo and redo actions on the workflow nodes using the `Ctrl+Z` and `Ctrl+Shift+Z` keyboard shortcuts, respectively. When a user undoes an action, the state of the nodes in the workflow is reverted to the previous state. Similarly, when a user redoes an action, the state of the nodes is restored to the previous state that was undone.

## How to Test

To test these features, follow the below steps:

1. Run the `langflow` application.
2. Add a few nodes to the workflow.
3. Select one or more nodes by holding down the `Shift` key and dragging the mouse over the nodes.
4. Press `Ctrl+C` to copy the selected nodes.
5. Leave the mouse pointer at a different location in the workflow and press `Ctrl+V` to paste the copied nodes.
6. Use the `Ctrl+Z` and `Ctrl+Shift+Z` keyboard shortcuts to undo and redo actions on the nodes in the workflow.