### PR TITLE
Hotfix: remove deepcopy, fixes llm rebuilding 

### DIFF
--- a/src/backend/langflow/api/chat_manager.py
+++ b/src/backend/langflow/api/chat_manager.py
@@ -110,7 +110,7 @@ class ChatManager:
         start_resp = ChatResponse(message=None, type="start", intermediate_steps="")
         await self.send_json(client_id, start_resp)
 
-        is_first_message = len(self.chat_history.get_history(client_id=client_id)) == 0
+        is_first_message = len(self.chat_history.get_history(client_id=client_id)) <= 1
         # Generate result and thought
         try:
             logger.debug("Generating result and thought")

--- a/src/backend/langflow/interface/loading.py
+++ b/src/backend/langflow/interface/loading.py
@@ -134,7 +134,13 @@ def instantiate_documentloader(class_object, params):
 
 
 def instantiate_textsplitter(class_object, params):
-    documents = params.pop("documents")
+    try:
+        documents = params.pop("documents")
+    except KeyError as e:
+        raise ValueError(
+            "The source you provided did not load correctly or was empty."
+            "Try changing the chunk_size of the Text Splitter."
+        ) from e
     text_splitter = class_object(**params)
     return text_splitter.split_documents(documents)
 


### PR DESCRIPTION
This PR removes deepcopy from all Node build methods and prevents LLMs of being loaded more than once.

Fixes #340