### PR TITLE
fix crash when upload large file, not saving files on browser storage

### DIFF
--- a/src/frontend/src/contexts/tabsContext.tsx
+++ b/src/frontend/src/contexts/tabsContext.tsx
@@ -50,10 +50,23 @@ export function TabsProvider({ children }: { children: ReactNode }) {
 		return newNodeId.current;
 	}
 	function save() {
-		if (flows.length !== 0)
+		let Saveflows = [...flows];
+		if (Saveflows.length !== 0)
+		Saveflows.forEach((flow) => {
+			if(flow.data && flow.data?.nodes) flow.data?.nodes.forEach((node) => {
+				console.log(node.data.type)
+				Object.keys(node.data.node.template).forEach((key) => {
+					console.log(node.data.node.template[key].type)
+					if(node.data.node.template[key].type==="file"){
+						console.log(node.data.node.template[key])
+						node.data.node.template[key].content = "";
+					}
+				})
+			})
+		})
 			window.localStorage.setItem(
 				"tabsData",
-				JSON.stringify({ tabIndex, flows, id})
+				JSON.stringify({ tabIndex, flows:Saveflows, id})
 			);
 	}
 	useEffect(() => {


### PR DESCRIPTION
This pull request focuses on a specific change in the file upload functionality, specifically related to browser storage. Currently, when users upload large files, the system automatically saves the files on the browser's local storage, consuming unnecessary storage space and potentially breaking the app. This pull request introduces a modification to disable the saving of files on browser storage.

By merging this pull request, we ensure that files uploaded by users are no longer saved on the browser's local storage.