### PR TITLE
fix: SQLAgent

### DIFF
--- a/src/backend/langflow/interface/agents/custom.py
+++ b/src/backend/langflow/interface/agents/custom.py
@@ -220,7 +220,7 @@ class SQLAgent(CustomAgentExecutor):
             QuerySQLDataBaseTool(db=db),  # type: ignore
             InfoSQLDatabaseTool(db=db),  # type: ignore
             ListSQLDatabaseTool(db=db),  # type: ignore
-            QueryCheckerTool(db=db, llm_chain=llmchain),  # type: ignore
+            QueryCheckerTool(db=db, llm_chain=llmchain, llm=llm),  # type: ignore
         ]
 
         prefix = SQL_PREFIX.format(dialect=toolkit.dialect, top_k=10)


### PR DESCRIPTION
First of all, thanks for the nice project. It's perfect for prototyping langchain setup/parameters.

The queryCheckerTool now needs an extra arg with the LLM instance: https://github.com/hwchase17/langchain/blob/master/langchain/tools/sql_database/tool.py#L108

I added it so the SQLAgent can work normally now

Here's a screen shot of the error:

<img width="1510" alt="Screenshot 2023-05-27 at 14 12 47" src="https://github.com/gabfr/langflow/assets/1237163/299b0075-5d32-47d6-9112-b5795b0f0532">

Here's a screen shot of the flow I was testing:

<img width="2553" alt="Screenshot 2023-05-27 at 14 13 39" src="https://github.com/gabfr/langflow/assets/1237163/93ea6e58-5020-4c09-b9b0-e5adf8dec128">
