### PR TITLE
🚀 feat(langflow): add support for extra fields in VectorStoreFrontendNode

### DIFF
--- a/src/backend/langflow/interface/base.py
+++ b/src/backend/langflow/interface/base.py
@@ -53,30 +53,33 @@ class LangChainTypeCreator(BaseModel, ABC):
         signature = self.get_signature(name)
         if signature is None:
             logger.error(f"Node {name} not loaded")
-            return None
-        if isinstance(signature, FrontendNode):
             return signature
-        fields = [
-            TemplateField(
-                name=key,
-                field_type=value["type"],
-                required=value.get("required", False),
-                placeholder=value.get("placeholder", ""),
-                is_list=value.get("list", False),
-                show=value.get("show", True),
-                multiline=value.get("multiline", False),
-                value=value.get("value", None),
-                suffixes=value.get("suffixes", []),
-                file_types=value.get("fileTypes", []),
-                content=value.get("content", None),
+        if not isinstance(signature, FrontendNode):
+            fields = [
+                TemplateField(
+                    name=key,
+                    field_type=value["type"],
+                    required=value.get("required", False),
+                    placeholder=value.get("placeholder", ""),
+                    is_list=value.get("list", False),
+                    show=value.get("show", True),
+                    multiline=value.get("multiline", False),
+                    value=value.get("value", None),
+                    suffixes=value.get("suffixes", []),
+                    file_types=value.get("fileTypes", []),
+                    content=value.get("content", None),
+                )
+                for key, value in signature["template"].items()
+                if key != "_type"
+            ]
+            template = Template(type_name=name, fields=fields)
+            signature = self.frontend_node_class(
+                template=template,
+                description=signature.get("description", ""),
+                base_classes=signature["base_classes"],
+                name=name,
             )
-            for key, value in signature["template"].items()
-            if key != "_type"
-        ]
-        template = Template(type_name=name, fields=fields)
-        return self.frontend_node_class(
-            template=template,
-            description=signature.get("description", ""),
-            base_classes=signature["base_classes"],
-            name=name,
-        )
+
+        signature.add_extra_fields()
+
+        return signature

--- a/src/backend/langflow/template/frontend_node/base.py
+++ b/src/backend/langflow/template/frontend_node/base.py
@@ -24,6 +24,9 @@ class FrontendNode(BaseModel):
             }
         }
 
+    def add_extra_fields(self) -> None:
+        pass
+
     @staticmethod
     def format_field(field: TemplateField, name: Optional[str] = None) -> None:
         """Formats a given field based on its attributes and value."""

--- a/src/backend/langflow/template/frontend_node/vectorstores.py
+++ b/src/backend/langflow/template/frontend_node/vectorstores.py
@@ -5,6 +5,21 @@ from langflow.template.frontend_node.base import FrontendNode
 
 
 class VectorStoreFrontendNode(FrontendNode):
+    def add_extra_fields(self) -> None:
+        if self.template.type_name == "Weaviate":
+            extra_field = TemplateField(
+                name="weaviate_url",
+                field_type="str",
+                required=True,
+                placeholder="http://localhost:8080",
+                show=True,
+                advanced=False,
+                multiline=False,
+                value="http://localhost:8080",
+            )
+
+            self.template.add_field(extra_field)
+
     @staticmethod
     def format_field(field: TemplateField, name: Optional[str] = None) -> None:
         FrontendNode.format_field(field, name)

--- a/src/backend/langflow/template/template/base.py
+++ b/src/backend/langflow/template/template/base.py
@@ -23,3 +23,6 @@ class Template(BaseModel):
         result = {field.name: field.to_dict() for field in self.fields}
         result["_type"] = self.type_name  # type: ignore
         return result
+
+    def add_field(self, field: TemplateField) -> None:
+        self.fields.append(field)


### PR DESCRIPTION
✨ feat(template): add method to add fields to a template
The VectorStoreFrontendNode now supports adding extra fields to its template. The add_extra_fields method is called after the node is loaded and adds the weaviate_url field to the template if the node is of type Weaviate. The Template class now has a method to add fields to a template. This method is used by the VectorStoreFrontendNode to add the weaviate_url field to its template.