### PR TITLE
Added format_instructions to ZeroShotPrompt

### DIFF
--- a/src/backend/langflow/template/frontend_node/prompts.py
+++ b/src/backend/langflow/template/frontend_node/prompts.py
@@ -89,18 +89,18 @@ class ZeroShotPromptNode(BasePromptFrontendNode):
                 is_list=False,
                 show=True,
                 multiline=True,
-                value=prompt.SUFFIX,
-                name="suffix",
+                value=prompt.FORMAT_INSTRUCTIONS,
+                name="format_instructions",
             ),
             TemplateField(
                 field_type="str",
-                required=False,
+                required=True,
                 placeholder="",
                 is_list=False,
                 show=True,
                 multiline=True,
-                value=prompt.FORMAT_INSTRUCTIONS,
-                name="format_instructions",
+                value=prompt.SUFFIX,
+                name="suffix",
             ),
         ],
     )
@@ -109,3 +109,7 @@ class ZeroShotPromptNode(BasePromptFrontendNode):
 
     def to_dict(self):
         return super().to_dict()
+
+    @staticmethod
+    def format_field(field: TemplateField, name: Optional[str] = None) -> None:
+        PromptFrontendNode.format_field(field, name)

--- a/src/backend/langflow/utils/util.py
+++ b/src/backend/langflow/utils/util.py
@@ -273,6 +273,7 @@ def format_dict(d, name: Optional[str] = None):
             "examples",
             "code",
             "headers",
+            "format_instructions",
         ]
 
         # Replace dict type with str

--- a/tests/test_prompts_template.py
+++ b/tests/test_prompts_template.py
@@ -182,7 +182,7 @@ def test_zero_shot_prompt(client: TestClient):
         "value": "Answer the following questions as best you can. You have access to the following tools:",  # noqa: E501
         "password": False,
         "name": "prefix",
-        "type": "str",
+        "type": "prompt",
         "list": False,
         "advanced": False,
     }
@@ -194,19 +194,19 @@ def test_zero_shot_prompt(client: TestClient):
         "value": "Begin!\n\nQuestion: {input}\nThought:{agent_scratchpad}",
         "password": False,
         "name": "suffix",
-        "type": "str",
+        "type": "prompt",
         "list": False,
         "advanced": False,
     }
     assert template["format_instructions"] == {
-        "required": False,
+        "required": True,
         "placeholder": "",
-        "show": False,
-        "multiline": False,
+        "show": True,
+        "multiline": True,
         "value": "Use the following format:\n\nQuestion: the input question you must answer\nThought: you should always think about what to do\nAction: the action to take, should be one of [{tool_names}]\nAction Input: the input to the action\nObservation: the result of the action\n... (this Thought/Action/Action Input/Observation can repeat N times)\nThought: I now know the final answer\nFinal Answer: the final answer to the original input question",  # noqa: E501
         "password": False,
         "name": "format_instructions",
-        "type": "str",
+        "type": "prompt",
         "list": False,
         "advanced": False,
     }


### PR DESCRIPTION
🔨 refactor(util.py): add format_instructions to the list of fields to format in format_dict function
The suffix and format_instructions fields in the ZeroShotPromptNode class were swapped to improve the readability of the code. The format_instructions field is now above the suffix field, which makes more sense as it is a required field. In the util.py file, the format_instructions field was added to the list of fields to format in the format_dict function. This ensures that the format_instructions field is properly formatted when the function is called.