### PR TITLE
🔖 chore(pyproject.toml): bump up version to 0.0.83

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langflow"
-version = "0.0.82"
+version = "0.0.83"
 description = "A Python package with a built-in web application"
 authors = ["Logspace <contact@logspace.ai>"]
 maintainers = [


### PR DESCRIPTION
The version number in the pyproject.toml file has been updated from 0.0.82 to 0.0.83. This commit exists because the release action did not work.