### PR TITLE
Fix: Key error when creating SeriesCharacterPrompt

### DIFF
--- a/src/backend/langflow/interface/prompts/custom.py
+++ b/src/backend/langflow/interface/prompts/custom.py
@@ -65,7 +65,7 @@ Human: {input}
 {character}:"""
 
     ai_prefix: str = "{character}"
-    input_variables: List[str] = ["character", "series"]
+    input_variables: List[str] = ["character", "series", "history","input"]
 
 
 CUSTOM_PROMPTS: Dict[str, Type[BaseCustomPrompt]] = {


### PR DESCRIPTION
The input_variables should specify all the variables in the template.