### PR TITLE
Fix: Restore Notion and Slack directory loaders.

### DIFF
--- a/src/backend/langflow/template/frontend_node/documentloaders.py
+++ b/src/backend/langflow/template/frontend_node/documentloaders.py
@@ -42,6 +42,7 @@ class DocumentLoaderFrontNode(FrontendNode):
             suffixes=[".pptx", ".ppt"], fileTypes=["pptx", "ppt"]
         ),
         "SRTLoader": build_template(suffixes=[".srt"], fileTypes=["srt"]),
+        "SlackDirectoryLoader": build_template(suffixes=[".zip"], fileTypes=["zip"]),
         "TelegramChatLoader": build_template(suffixes=[".json"], fileTypes=["json"]),
         "TextLoader": build_template(suffixes=[".txt"], fileTypes=["txt"]),
         "UnstructuredWordDocumentLoader": build_template(
@@ -64,7 +65,10 @@ class DocumentLoaderFrontNode(FrontendNode):
             name = "web_path"
         elif self.template.type_name in {"GitbookLoader"}:
             name = "web_page"
-        elif self.template.type_name in {"ReadTheDocsLoader"}:
+        elif self.template.type_name in {
+            "ReadTheDocsLoader",
+            "NotionDirectoryLoader",
+        }:
             name = "path"
         if name:
             self.template.add_field(

--- a/src/backend/langflow/template/frontend_node/documentloaders.py
+++ b/src/backend/langflow/template/frontend_node/documentloaders.py
@@ -41,8 +41,8 @@ class DocumentLoaderFrontNode(FrontendNode):
         "UnstructuredPowerPointLoader": build_template(
             suffixes=[".pptx", ".ppt"], fileTypes=["pptx", "ppt"]
         ),
-        "SRTLoader": build_template(suffixes=[".srt"], fileTypes=["srt"]),
         "SlackDirectoryLoader": build_template(suffixes=[".zip"], fileTypes=["zip"]),
+        "SRTLoader": build_template(suffixes=[".srt"], fileTypes=["srt"]),
         "TelegramChatLoader": build_template(suffixes=[".json"], fileTypes=["json"]),
         "TextLoader": build_template(suffixes=[".txt"], fileTypes=["txt"]),
         "UnstructuredWordDocumentLoader": build_template(
@@ -66,8 +66,8 @@ class DocumentLoaderFrontNode(FrontendNode):
         elif self.template.type_name in {"GitbookLoader"}:
             name = "web_page"
         elif self.template.type_name in {
-            "ReadTheDocsLoader",
             "NotionDirectoryLoader",
+            "ReadTheDocsLoader",
         }:
             name = "path"
         if name:

--- a/src/backend/langflow/template/frontend_node/documentloaders.py
+++ b/src/backend/langflow/template/frontend_node/documentloaders.py
@@ -3,7 +3,6 @@ from langflow.template.frontend_node.base import FrontendNode
 
 
 class DocumentLoaderFrontNode(FrontendNode):
-    @staticmethod
     def build_template(
         suffixes: list, fileTypes: list, name: str = "file_path"
     ) -> TemplateField:
@@ -52,6 +51,7 @@ class DocumentLoaderFrontNode(FrontendNode):
 
     def add_extra_fields(self) -> None:
         name = None
+        display_name = "Web Page"
         if self.template.type_name in self.file_path_templates:
             self.template.add_field(self.file_path_templates[self.template.type_name])
         elif self.template.type_name in {
@@ -70,6 +70,7 @@ class DocumentLoaderFrontNode(FrontendNode):
             "ReadTheDocsLoader",
         }:
             name = "path"
+            display_name = "Local directory"
         if name:
             self.template.add_field(
                 TemplateField(
@@ -78,6 +79,6 @@ class DocumentLoaderFrontNode(FrontendNode):
                     show=True,
                     name=name,
                     value="",
-                    display_name="Web Page",
+                    display_name=display_name,
                 )
             )

--- a/src/backend/langflow/template/frontend_node/documentloaders.py
+++ b/src/backend/langflow/template/frontend_node/documentloaders.py
@@ -3,6 +3,7 @@ from langflow.template.frontend_node.base import FrontendNode
 
 
 class DocumentLoaderFrontNode(FrontendNode):
+    @staticmethod
     def build_template(
         suffixes: list, fileTypes: list, name: str = "file_path"
     ) -> TemplateField:


### PR DESCRIPTION
I'd noticed that in `0.0.88` the `path` for `NotionDirectoryLoader` and the `file` for `SlackDirectoryLoader` were missing. This PR restores those input fields.