### PR TITLE
Remove unnecessary text-sm class from message sender name to improve readability

### DIFF
--- a/src/frontend/src/modals/chatModal/chatMessage/index.tsx
+++ b/src/frontend/src/modals/chatModal/chatMessage/index.tsx
@@ -152,7 +152,7 @@ export default function ChatMessage({
         </div>
       ) : (
         <div className="w-full flex items-center">
-          <div className="text-start inline-block px-3 text-sm text-gray-600 dark:text-white">
+          <div className="text-start inline-block px-3 text-gray-600 dark:text-white">
             <span
               className="text-gray-600 dark:text-gray-200"
               dangerouslySetInnerHTML={{


### PR DESCRIPTION
🐛 fix(chatMessage): remove unnecessary text-sm class from message sender name to improve readability