### PR TITLE
🔧 chore(chat.py): add build step for root node in graph

### DIFF
--- a/src/backend/langflow/api/v1/chat.py
+++ b/src/backend/langflow/api/v1/chat.py
@@ -113,6 +113,14 @@ async def stream_build(flow_id: str):
 
             number_of_nodes = len(graph.nodes)
             flow_data_store[flow_id]["status"] = BuildStatus.IN_PROGRESS
+            # To deal with the ZeroShotAgent case
+            # we need to build the root node first
+            # and then the rest of the graph
+            # This is a big problem because certain nodes require
+            # params that are not connected to it.
+            # We should consider connecting the tools to the ZeroShotPrompt
+            graph.build()
+
             for i, vertex in enumerate(graph.generator_build(), 1):
                 try:
                     log_dict = {


### PR DESCRIPTION
📝 docs(chat.py): explain the need for building the root node before the rest of the graph
The root node in the graph was not being built before the rest of the graph, which caused issues when certain nodes required parameters that were not connected to them. By adding the missing build step for the root node, we ensure that all necessary connections and parameters are properly set up before building the rest of the graph. This improves the overall functionality and reliability of the chat module.