### PR TITLE
Add Auto-numbering for Duplicate Forking Flows

### DIFF
--- a/src/frontend/src/contexts/tabsContext.tsx
+++ b/src/frontend/src/contexts/tabsContext.tsx
@@ -20,7 +20,7 @@ import {
 import { APIClassType, APITemplateType } from "../types/api";
 import { FlowType, NodeType } from "../types/flow";
 import { TabsContextType, TabsState } from "../types/tabs";
-import { updateIds, updateTemplate } from "../utils/reactflowUtils";
+import { addVersionToDuplicates, updateIds, updateTemplate } from "../utils/reactflowUtils";
 import { getRandomDescription, getRandomName } from "../utils/utils";
 import { alertContext } from "./alertContext";
 import { typesContext } from "./typesContext";
@@ -447,6 +447,10 @@ export function TabsProvider({ children }: { children: ReactNode }) {
       const newFlow = createNewFlow(flowData, flow);
       processFlowEdges(newFlow);
       processFlowNodes(newFlow);
+
+      const flowName = addVersionToDuplicates(newFlow, flows);
+
+      newFlow.name = flowName;
 
       try {
         const { id } = await saveFlowToDatabase(newFlow);

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -219,3 +219,16 @@ export function validateNodes(reactFlowInstance: ReactFlowInstance) {
     .getNodes()
     .flatMap((n: NodeType) => validateNode(n, reactFlowInstance));
 }
+
+export function addVersionToDuplicates(flow: FlowType, flows: FlowType[]) {
+  const existingNames = flows.map((item) => item.name);
+  let newName = flow.name;
+  let count = 1;
+
+  while (existingNames.includes(newName)) {
+    newName = `${flow.name} (${count})`;
+    count++;
+  }
+
+  return newName;
+}


### PR DESCRIPTION
This pull request aims to introduce a new feature to the project that automatically assigns a unique number to the name of a new flow when it is imported from the community examples and a flow with the same name already exists. This improvement will prevent naming conflicts and enhance the user experience by providing a clear distinction between similarly named flows.