### PR TITLE
Prevent Default on Ctrl + Backspace in ReactFlow

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -121,6 +121,20 @@ export default function App() {
     );
   };
 
+  const handleKeyPress = (e: KeyboardEvent) => {
+    if (e.ctrlKey && e.key === "Backspace") {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyPress);
+    return () => {
+      document.removeEventListener('keydown', handleKeyPress);
+    };
+  }, []);
+
   return (
     //need parent component with width and height
     <div className="flex h-full flex-col">

--- a/src/frontend/src/components/AccordionComponent/index.tsx
+++ b/src/frontend/src/components/AccordionComponent/index.tsx
@@ -32,6 +32,13 @@ export default function AccordionComponent({
     value === "" ? setValue(keyValue) : setValue("");
   }
 
+  const handleKeyDown = (event) => {
+    if (event.key === "Backspace") {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
   return (
     <>
       <Accordion
@@ -39,6 +46,7 @@ export default function AccordionComponent({
         className="w-full"
         value={value}
         onValueChange={setValue}
+        onKeyDown={handleKeyDown}
       >
         <AccordionItem value={keyValue} className="border-b">
           <AccordionTrigger

--- a/src/frontend/src/components/floatComponent/index.tsx
+++ b/src/frontend/src/components/floatComponent/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { FloatComponentType } from "../../types/components";
 import { Input } from "../ui/input";
+import { handleKeyDown } from "../../utils/reactflowUtils";
 
 export default function FloatComponent({
   value,
@@ -18,14 +19,6 @@ export default function FloatComponent({
       onChange("");
     }
   }, [disabled, onChange]);
-
-  const handleKeyDown = (e) => {
-    
-    if (e.ctrlKey && value === '0' && e.key === "Backspace") {
-      e.preventDefault();
-      e.stopPropagation();
-    }
-  };
 
   return (
     <div className="w-full">
@@ -51,7 +44,9 @@ export default function FloatComponent({
         onChange={(e) => {
           onChange(e.target.value);
         }}
-        onKeyDown={handleKeyDown}
+        onKeyDown={(e) => {
+          handleKeyDown(e, value, '0');
+        }}
       />
     </div>
   );

--- a/src/frontend/src/components/floatComponent/index.tsx
+++ b/src/frontend/src/components/floatComponent/index.tsx
@@ -19,6 +19,14 @@ export default function FloatComponent({
     }
   }, [disabled, onChange]);
 
+  const handleKeyDown = (e) => {
+    
+    if (e.ctrlKey && value === '0' && e.key === "Backspace") {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
+
   return (
     <div className="w-full">
       <Input
@@ -43,6 +51,7 @@ export default function FloatComponent({
         onChange={(e) => {
           onChange(e.target.value);
         }}
+        onKeyDown={handleKeyDown}
       />
     </div>
   );

--- a/src/frontend/src/components/inputComponent/index.tsx
+++ b/src/frontend/src/components/inputComponent/index.tsx
@@ -19,6 +19,14 @@ export default function InputComponent({
     }
   }, [disabled, onChange]);
 
+  const handleKeyDown = (e) => {
+    if (e.ctrlKey && value === '' && e.key === "Backspace") {
+      
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
+
   return (
     <div className="relative w-full">
       <Input
@@ -34,6 +42,7 @@ export default function InputComponent({
         onChange={(e) => {
           onChange(e.target.value);
         }}
+        onKeyDown={handleKeyDown}
       />
       {password && (
         <button

--- a/src/frontend/src/components/inputComponent/index.tsx
+++ b/src/frontend/src/components/inputComponent/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { InputComponentType } from "../../types/components";
 import { classNames } from "../../utils/utils";
 import { Input } from "../ui/input";
+import { handleKeyDown } from "../../utils/reactflowUtils";
 
 export default function InputComponent({
   value,
@@ -19,13 +20,6 @@ export default function InputComponent({
     }
   }, [disabled, onChange]);
 
-  const handleKeyDown = (e) => {
-    if (e.ctrlKey && value === '' && e.key === "Backspace") {
-      
-      e.preventDefault();
-      e.stopPropagation();
-    }
-  };
 
   return (
     <div className="relative w-full">
@@ -42,7 +36,9 @@ export default function InputComponent({
         onChange={(e) => {
           onChange(e.target.value);
         }}
-        onKeyDown={handleKeyDown}
+        onKeyDown={(e) => {
+          handleKeyDown(e, value, '');
+        }}
       />
       {password && (
         <button

--- a/src/frontend/src/components/inputListComponent/index.tsx
+++ b/src/frontend/src/components/inputListComponent/index.tsx
@@ -5,6 +5,7 @@ import _ from "lodash";
 import { classNames } from "../../utils/utils";
 import IconComponent from "../genericIconComponent";
 import { Input } from "../ui/input";
+import { handleKeyDown } from "../../utils/reactflowUtils";
 
 export default function InputListComponent({
   value,
@@ -17,15 +18,6 @@ export default function InputListComponent({
       onChange([""]);
     }
   }, [disabled]);
-
-  const handleKeyDown = (e) => {
-    
-    if (e.ctrlKey && e.key === "Backspace") {
-      
-      e.preventDefault();
-      e.stopPropagation();
-    }
-  };
 
   return (
     <div
@@ -48,8 +40,12 @@ export default function InputListComponent({
                 newInputList[idx] = e.target.value;
                 onChange(newInputList);
               }}
-            onKeyDown={handleKeyDown}
-
+              onKeyDown={(e) => {
+                if (e.ctrlKey && e.key === "Backspace") {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }
+              }}
             />
             {idx === value.length - 1 ? (
               <button

--- a/src/frontend/src/components/inputListComponent/index.tsx
+++ b/src/frontend/src/components/inputListComponent/index.tsx
@@ -18,6 +18,15 @@ export default function InputListComponent({
     }
   }, [disabled]);
 
+  const handleKeyDown = (e) => {
+    
+    if (e.ctrlKey && e.key === "Backspace") {
+      
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
+
   return (
     <div
       className={classNames(
@@ -39,6 +48,8 @@ export default function InputListComponent({
                 newInputList[idx] = e.target.value;
                 onChange(newInputList);
               }}
+            onKeyDown={handleKeyDown}
+
             />
             {idx === value.length - 1 ? (
               <button

--- a/src/frontend/src/components/intComponent/index.tsx
+++ b/src/frontend/src/components/intComponent/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { FloatComponentType } from "../../types/components";
 import { Input } from "../ui/input";
+import { handleKeyDown } from "../../utils/reactflowUtils";
 
 export default function IntComponent({
   value,
@@ -17,13 +18,7 @@ export default function IntComponent({
     }
   }, [disabled, onChange]);
 
-  const handleKeyDown = (e: React.ChangeEvent<HTMLInputElement>) => {
-    
-    if (e.ctrlKey && value === '0' && e.key === "Backspace") {
-      e.preventDefault();
-      e.stopPropagation();
-    }
-  };
+
 
   return (
     <div className="w-full">
@@ -45,6 +40,7 @@ export default function IntComponent({
           ) {
             event.preventDefault();
           }
+          handleKeyDown(event, value, '0');
         }}
         type="number"
         step="1"
@@ -61,7 +57,6 @@ export default function IntComponent({
         onChange={(e) => {
           onChange(e.target.value);
         }}
-        onKeyDown={handleKeyDown}
       />
     </div>
   );

--- a/src/frontend/src/components/intComponent/index.tsx
+++ b/src/frontend/src/components/intComponent/index.tsx
@@ -17,6 +17,14 @@ export default function IntComponent({
     }
   }, [disabled, onChange]);
 
+  const handleKeyDown = (e: React.ChangeEvent<HTMLInputElement>) => {
+    
+    if (e.ctrlKey && value === '0' && e.key === "Backspace") {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
+
   return (
     <div className="w-full">
       <Input
@@ -53,6 +61,7 @@ export default function IntComponent({
         onChange={(e) => {
           onChange(e.target.value);
         }}
+        onKeyDown={handleKeyDown}
       />
     </div>
   );

--- a/src/frontend/src/modals/codeAreaModal/index.tsx
+++ b/src/frontend/src/modals/codeAreaModal/index.tsx
@@ -72,13 +72,6 @@ export default function CodeAreaModal({
 
   const [open, setOpen] = useState(false);
 
-  const handleKeyDown = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.ctrlKey && code === '' && e.key === "Backspace") {
-      e.preventDefault();
-      e.stopPropagation();
-    }
-  };
-
   return (
     <BaseModal open={open} setOpen={setOpen}>
       <BaseModal.Trigger>{children}</BaseModal.Trigger>
@@ -106,7 +99,6 @@ export default function CodeAreaModal({
               onChange={(value) => {
                 setCode(value);
               }}
-              onKeyDown={handleKeyDown}
               className="h-full w-full rounded-lg border-[1px] border-border custom-scroll"
             />
           </div>

--- a/src/frontend/src/modals/codeAreaModal/index.tsx
+++ b/src/frontend/src/modals/codeAreaModal/index.tsx
@@ -72,6 +72,13 @@ export default function CodeAreaModal({
 
   const [open, setOpen] = useState(false);
 
+  const handleKeyDown = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.ctrlKey && code === '' && e.key === "Backspace") {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
+
   return (
     <BaseModal open={open} setOpen={setOpen}>
       <BaseModal.Trigger>{children}</BaseModal.Trigger>
@@ -99,6 +106,7 @@ export default function CodeAreaModal({
               onChange={(value) => {
                 setCode(value);
               }}
+              onKeyDown={handleKeyDown}
               className="h-full w-full rounded-lg border-[1px] border-border custom-scroll"
             />
           </div>

--- a/src/frontend/src/modals/genericModal/index.tsx
+++ b/src/frontend/src/modals/genericModal/index.tsx
@@ -165,6 +165,13 @@ export default function GenericModal({
       });
   }
 
+  const handleKeyDown = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.ctrlKey && inputValue === '' && e.key === "Backspace") {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
+
   const [modalOpen, setModalOpen] = useState(false);
 
   return (
@@ -212,6 +219,7 @@ export default function GenericModal({
                   setInputValue(e.target.value);
                   checkVariables(e.target.value);
                 }}
+                onKeyDown={handleKeyDown}
                 placeholder="Type message here."
               />
             ) : type === TypeModal.PROMPT && !isEdit ? (
@@ -224,6 +232,7 @@ export default function GenericModal({
                 onChange={(e) => {
                   setInputValue(e.target.value);
                 }}
+                onKeyDown={handleKeyDown}
                 placeholder="Type message here."
               />
             ) : (

--- a/src/frontend/src/modals/genericModal/index.tsx
+++ b/src/frontend/src/modals/genericModal/index.tsx
@@ -22,6 +22,7 @@ import {
   varHighlightHTML,
 } from "../../utils/utils";
 import BaseModal from "../baseModal";
+import { handleKeyDown } from "../../utils/reactflowUtils";
 
 export default function GenericModal({
   field_name = "",
@@ -165,13 +166,6 @@ export default function GenericModal({
       });
   }
 
-  const handleKeyDown = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.ctrlKey && inputValue === '' && e.key === "Backspace") {
-      e.preventDefault();
-      e.stopPropagation();
-    }
-  };
-
   const [modalOpen, setModalOpen] = useState(false);
 
   return (
@@ -219,8 +213,10 @@ export default function GenericModal({
                   setInputValue(e.target.value);
                   checkVariables(e.target.value);
                 }}
-                onKeyDown={handleKeyDown}
                 placeholder="Type message here."
+                onKeyDown={(e) => {
+                  handleKeyDown(e, inputValue, '');
+                }}
               />
             ) : type === TypeModal.PROMPT && !isEdit ? (
               <TextAreaContentView />
@@ -232,8 +228,10 @@ export default function GenericModal({
                 onChange={(e) => {
                   setInputValue(e.target.value);
                 }}
-                onKeyDown={handleKeyDown}
                 placeholder="Type message here."
+                onKeyDown={(e) => {
+                  handleKeyDown(e, value, '');
+                }}
               />
             ) : (
               <></>

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -235,8 +235,6 @@ export function addVersionToDuplicates(flow: FlowType, flows: FlowType[]) {
 
 export function handleKeyDown(e: React.ChangeEvent<HTMLInputElement>, inputValue: string | string[], block: string)
 {
-  console.log(e.ctrlKey, inputValue, e.key);
-  
   if (e.ctrlKey && inputValue === block && e.key === "Backspace") {
     e.preventDefault();
     e.stopPropagation();

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -233,7 +233,7 @@ export function addVersionToDuplicates(flow: FlowType, flows: FlowType[]) {
   return newName;
 }
 
-export function handleKeyDown(e: React.ChangeEvent<HTMLInputElement>, inputValue: string | string[], block: string)
+export function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>, inputValue: string | string[] | null, block: string)
 {
   if (e.ctrlKey && inputValue === block && e.key === "Backspace") {
     e.preventDefault();

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -232,3 +232,13 @@ export function addVersionToDuplicates(flow: FlowType, flows: FlowType[]) {
 
   return newName;
 }
+
+export function handleKeyDown(e: React.ChangeEvent<HTMLInputElement>, inputValue: string | string[], block: string)
+{
+  console.log(e.ctrlKey, inputValue, e.key);
+  
+  if (e.ctrlKey && inputValue === block && e.key === "Backspace") {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+};


### PR DESCRIPTION
Fixes the issue where using Ctrl + Backspace in ReactFlow caused unwanted default behavior. This pull request addresses the problem by preventing the default action when the user presses Ctrl + Backspace, allowing for a smoother and more intuitive experience when interacting with the application.

🐛 fix(floatComponent): prevent default behavior when pressing Ctrl+Backspace on input with value '0'
🐛 fix(inputComponent): prevent default behavior when pressing Ctrl+Backspace on empty input
🐛 fix(inputListComponent): prevent default behavior when pressing Ctrl+Backspace on any input
🐛 fix(intComponent): prevent default behavior when pressing Ctrl+Backspace on input with value '0'
🐛 fix(codeAreaModal): prevent default behavior when pressing Ctrl+Backspace on empty code area
🐛 fix(genericModal): prevent default behavior when pressing Ctrl+Backspace on empty input