### PR TITLE
PromptTemplate textArea dont show up as in node class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,10 @@ lint:
 	poetry run ruff . --fix
 
 install_frontend:
-	cd src/frontend && npm install;
+	cd src/frontend && npm install
 
 install_frontendc:
-	cd src/frontend && rm -rf node_modules package-lock.json && npm install;
+	cd src/frontend && rm -rf node_modules package-lock.json && npm install
 
 run_frontend:
 	cd src/frontend && npm start

--- a/src/frontend/src/components/promptComponent/index.tsx
+++ b/src/frontend/src/components/promptComponent/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import { TypeModal } from "../../constants/enums";
 import { postValidatePrompt } from "../../controllers/API";
@@ -32,13 +32,6 @@ export default function PromptAreaComponent({
     }
   }, []);
 
-  const [inputValue, setInputValue] = useState(value);
-
-  useEffect(() => {
-    console.log("value", value);
-    
-  }, [inputValue])
-
   return (
     <div className={disabled ? "pointer-events-none w-full " : " w-full"}>
       <GenericModal
@@ -48,7 +41,6 @@ export default function PromptAreaComponent({
         modalTitle="Edit Prompt"
         setValue={(value: string) => {
           onChange(value);
-          setInputValue(value);
         }}
         nodeClass={nodeClass}
         setNodeClass={setNodeClass}

--- a/src/frontend/src/components/promptComponent/index.tsx
+++ b/src/frontend/src/components/promptComponent/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { TypeModal } from "../../constants/enums";
 import { postValidatePrompt } from "../../controllers/API";
@@ -32,6 +32,13 @@ export default function PromptAreaComponent({
     }
   }, []);
 
+  const [inputValue, setInputValue] = useState(value);
+
+  useEffect(() => {
+    console.log("value", value);
+    
+  }, [inputValue])
+
   return (
     <div className={disabled ? "pointer-events-none w-full " : " w-full"}>
       <GenericModal
@@ -41,6 +48,7 @@ export default function PromptAreaComponent({
         modalTitle="Edit Prompt"
         setValue={(value: string) => {
           onChange(value);
+          setInputValue(value);
         }}
         nodeClass={nodeClass}
         setNodeClass={setNodeClass}

--- a/src/frontend/src/modals/genericModal/index.tsx
+++ b/src/frontend/src/modals/genericModal/index.tsx
@@ -196,15 +196,18 @@ export default function GenericModal({
                 className="form-input h-full w-full rounded-lg custom-scroll focus-visible:ring-1"
                 value={inputValue}
                 onBlur={() => {
+                  setValue(inputValue);
+                  setInputValue(inputValue);
                   setIsEdit(false);
                 }}
                 autoFocus
                 onChange={(event) => {
+                  setValue(inputValue);
                   setInputValue(event.target.value);
                   checkVariables(event.target.value);
                 }}
                 placeholder="Type message here."
-                onKeyDown={(e) => {
+                onKeyDown={(e: any) => {
                   handleKeyDown(e, inputValue, "");
                 }}
               />

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -247,7 +247,6 @@ export function handleKeyDown(
   inputValue: string | string[] | null,
   block: string
 ) {
-  console.log(e, inputValue, block);
   //condition to fix bug control+backspace on Windows/Linux
   if (
     (typeof inputValue === "string" &&


### PR DESCRIPTION
🔧 chore(Makefile): remove unnecessary semicolon in install_frontend and install_frontendc targets
🔧 chore(Makefile): remove package-lock.json before running npm install in install_frontendc target
🔧 chore(Makefile): remove unnecessary console.log statement in handleKeyDown function in reactflowUtils.ts
🔧 chore(genericModal/index.tsx): remove unnecessary setValue and setInputValue calls in onBlur and onChange event handlers
✨ feat(promptComponent/index.tsx): add inputValue state and update onChange and setValue event handlers to set inputValue