### PR TITLE
Node not deleting input when deletes a variable inside a prompt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,10 +7,19 @@
 *.h text
 *.py text
 *.js text
-*.ts text
 *.jsx text
+*.ts text
+*.tsx text
 *.md text
 *.mdx text
+*.yml text
+*.yaml text
+*.xml text
+*.csv text
+*.json text
+*.sh text
+*.Dockerfile text
+Dockerfile text
 
 # Declare files that will always have CRLF line endings on checkout.
 *.sln text eol=crlf
@@ -18,3 +27,8 @@
 # Denote all files that are truly binary and should not be modified.
 *.png binary
 *.jpg binary
+*.ico binary
+*.gif binary
+*.mp4 binary
+*.svg binary
+*.csv binary

--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,10 @@ lint:
 	poetry run ruff . --fix
 
 install_frontend:
-	cd src/frontend && npm install;
+	cd src/frontend && npm install
 
 install_frontendc:
-	cd src/frontend && rm -rf node_modules package-lock.json && npm install;
+	cd src/frontend && rm -rf node_modules package-lock.json && npm install
 
 run_frontend:
 	cd src/frontend && npm start

--- a/src/frontend/src/CustomNodes/GenericNode/components/parameterComponent/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/parameterComponent/index.tsx
@@ -333,8 +333,6 @@ export default function ParameterComponent({
             <PromptAreaComponent
               field_name={name}
               setNodeClass={(nodeClass) => {
-                console.log(nodeClass);
-                
                 data.node = nodeClass;
               }}
               nodeClass={data.node}

--- a/src/frontend/src/CustomNodes/GenericNode/components/parameterComponent/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/parameterComponent/index.tsx
@@ -333,6 +333,8 @@ export default function ParameterComponent({
             <PromptAreaComponent
               field_name={name}
               setNodeClass={(nodeClass) => {
+                console.log(nodeClass);
+                
                 data.node = nodeClass;
               }}
               nodeClass={data.node}

--- a/src/frontend/src/components/promptComponent/index.tsx
+++ b/src/frontend/src/components/promptComponent/index.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import { TypeModal } from "../../constants/enums";
 import { postValidatePrompt } from "../../controllers/API";
 import GenericModal from "../../modals/genericModal";
-import { TextAreaComponentType } from "../../types/components";
+import { PromptAreaComponentType } from "../../types/components";
 import IconComponent from "../genericIconComponent";
 
 export default function PromptAreaComponent({
@@ -14,7 +14,7 @@ export default function PromptAreaComponent({
   onChange,
   disabled,
   editNode = false,
-}: TextAreaComponentType): JSX.Element {
+}: PromptAreaComponentType): JSX.Element {
   useEffect(() => {
     if (disabled) {
       onChange("");

--- a/src/frontend/src/components/promptComponent/index.tsx
+++ b/src/frontend/src/components/promptComponent/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import { TypeModal } from "../../constants/enums";
 import { postValidatePrompt } from "../../controllers/API";
@@ -32,13 +32,6 @@ export default function PromptAreaComponent({
     }
   }, []);
 
-  const [inputValue, setInputValue] = useState(value);
-
-  useEffect(() => {
-    console.log("value", value);
-    
-  }, [inputValue])
-
   return (
     <div className={disabled ? "pointer-events-none w-full " : " w-full"}>
       <GenericModal
@@ -48,7 +41,6 @@ export default function PromptAreaComponent({
         modalTitle="Edit Prompt"
         setValue={(value: string) => {
           onChange(value);
-          setInputValue(value);
         }}
         nodeClass={nodeClass}
         setNodeClass={setNodeClass}

--- a/src/frontend/src/components/promptComponent/index.tsx
+++ b/src/frontend/src/components/promptComponent/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { TypeModal } from "../../constants/enums";
 import { postValidatePrompt } from "../../controllers/API";
@@ -32,6 +32,13 @@ export default function PromptAreaComponent({
     }
   }, []);
 
+  const [inputValue, setInputValue] = useState(value);
+
+  useEffect(() => {
+    console.log("value", value);
+    
+  }, [inputValue])
+
   return (
     <div className={disabled ? "pointer-events-none w-full " : " w-full"}>
       <GenericModal
@@ -41,6 +48,7 @@ export default function PromptAreaComponent({
         modalTitle="Edit Prompt"
         setValue={(value: string) => {
           onChange(value);
+          setInputValue(value);
         }}
         nodeClass={nodeClass}
         setNodeClass={setNodeClass}

--- a/src/frontend/src/modals/genericModal/index.tsx
+++ b/src/frontend/src/modals/genericModal/index.tsx
@@ -196,15 +196,18 @@ export default function GenericModal({
                 className="form-input h-full w-full rounded-lg custom-scroll focus-visible:ring-1"
                 value={inputValue}
                 onBlur={() => {
+                  setValue(inputValue);
+                  setInputValue(inputValue);
                   setIsEdit(false);
                 }}
                 autoFocus
                 onChange={(event) => {
+                  setValue(inputValue);
                   setInputValue(event.target.value);
                   checkVariables(event.target.value);
                 }}
                 placeholder="Type message here."
-                onKeyDown={(e) => {
+                onKeyDown={(e: any) => {
                   handleKeyDown(e, inputValue, "");
                 }}
               />

--- a/src/frontend/src/types/components/index.ts
+++ b/src/frontend/src/types/components/index.ts
@@ -64,6 +64,16 @@ export type TextAreaComponentType = {
   editNode?: boolean;
 };
 
+export type PromptAreaComponentType = {
+  field_name?: string;
+  nodeClass?: APIClassType;
+  setNodeClass?: (value: APIClassType) => void;
+  disabled: boolean;
+  onChange: (value: string[] | string) => void;
+  value: string;
+  editNode?: boolean;
+};
+
 export type CodeAreaComponentType = {
   disabled: boolean;
   onChange: (value: string[] | string) => void;

--- a/src/frontend/src/utils/reactflowUtils.ts
+++ b/src/frontend/src/utils/reactflowUtils.ts
@@ -247,7 +247,6 @@ export function handleKeyDown(
   inputValue: string | string[] | null,
   block: string
 ) {
-  console.log(e, inputValue, block);
   //condition to fix bug control+backspace on Windows/Linux
   if (
     (typeof inputValue === "string" &&


### PR DESCRIPTION
This pull request addresses the issue where the input node fails to delete input when a variable is deleted within a prompt. The problem arises due to the current implementation not properly handling the removal of variables within the prompt context, leading to lingering input that should be cleared.