### PR TITLE
 Add support for Azure OpenAI, Palm, Claude-2, Llama2, CodeLlama (100+LLMs) - using LiteLLM

### DIFF
--- a/docs/docs/components/llms.mdx
+++ b/docs/docs/components/llms.mdx
@@ -88,6 +88,18 @@ Make sure to have the `ctransformers` python package installed. Learn more about
 
 ---
 
+### ChatLiteLLM
+
+LiteLLM is a lightweight package to simplify LLM API calls - Azure, OpenAI, Cohere, Anthropic, Replicate. Manages input/output translation
+https://github.com/BerriAI/litellm/
+
+- **max_tokens:** The maximum number of tokens to generate in the completion. `-1` returns as many tokens as possible, given the prompt and the model's maximal context size – defaults to `256`.
+- **model_kwargs:** Holds any model parameters valid for creating non-specified calls.
+- **model_name:** Defines the OpenAI chat model to be used.
+- **temperature:** Tunes the degree of randomness in text generations. Should be a non-negative value – defaults to `0.7`.
+
+---
+
 ### ChatOpenAI
 
 Wrapper around [OpenAI's](https://openai.com) chat large language models. This component supports some of the LLMs (Large Language Models) available by OpenAI and is used for tasks such as chatbots, Generative Question-Answering (GQA), and summarization.

--- a/src/backend/langflow/interface/custom_lists.py
+++ b/src/backend/langflow/interface/custom_lists.py
@@ -15,6 +15,7 @@ from langchain.chat_models import (
     ChatOpenAI,
     ChatVertexAI,
     ChatAnthropic,
+    ChatLiteLLM,
 )
 
 from langflow.interface.importing.utils import import_class
@@ -27,6 +28,7 @@ llm_type_to_cls_dict["anthropic-chat"] = ChatAnthropic  # type: ignore
 llm_type_to_cls_dict["azure-chat"] = AzureChatOpenAI  # type: ignore
 llm_type_to_cls_dict["openai-chat"] = ChatOpenAI  # type: ignore
 llm_type_to_cls_dict["vertexai-chat"] = ChatVertexAI  # type: ignore
+llm_type_to_cls_dict["litellm-chat"] = ChatLiteLLM  # type: ignore
 
 
 # Toolkits

--- a/src/backend/langflow/template/frontend_node/base.py
+++ b/src/backend/langflow/template/frontend_node/base.py
@@ -175,6 +175,7 @@ class FrontendNode(BaseModel):
             "ChatOpenAI": constants.CHAT_OPENAI_MODELS,
             "Anthropic": constants.ANTHROPIC_MODELS,
             "ChatAnthropic": constants.ANTHROPIC_MODELS,
+            "ChatLiteLLM": constants.LITELLM_MODELS,
         }
         if name in model_dict and key == "model_name":
             field.options = model_dict[name]

--- a/src/backend/langflow/template/frontend_node/formatter/field_formatters.py
+++ b/src/backend/langflow/template/frontend_node/formatter/field_formatters.py
@@ -8,6 +8,7 @@ from langflow.utils.constants import (
     ANTHROPIC_MODELS,
     CHAT_OPENAI_MODELS,
     OPENAI_MODELS,
+    LITELLM_MODELS,
 )
 
 
@@ -26,6 +27,7 @@ class ModelSpecificFieldFormatter(FieldFormatter):
         "ChatOpenAI": CHAT_OPENAI_MODELS,
         "Anthropic": ANTHROPIC_MODELS,
         "ChatAnthropic": ANTHROPIC_MODELS,
+        "ChatLiteLLM": LITELLM_MODELS
     }
 
     def format(self, field: TemplateField, name: Optional[str] = None) -> None:

--- a/src/backend/langflow/utils/constants.py
+++ b/src/backend/langflow/utils/constants.py
@@ -42,6 +42,10 @@ ANTHROPIC_MODELS = [
     "claude-instant-v1.0",
 ]
 
+# litellm supported LLMs
+import litellm
+LITELLM_MODELS = litellm.model_list
+
 DEFAULT_PYTHON_FUNCTION = """
 def python_function(text: str) -> str:
     \"\"\"This is a default python function that returns the input text\"\"\"

--- a/src/backend/langflow/utils/util.py
+++ b/src/backend/langflow/utils/util.py
@@ -450,6 +450,8 @@ def add_options_to_field(
         "ChatOpenAI": constants.CHAT_OPENAI_MODELS,
         "Anthropic": constants.ANTHROPIC_MODELS,
         "ChatAnthropic": constants.ANTHROPIC_MODELS,
+        "ChatLiteLLM": constants.LITELLM_MODELS,
+
     }
 
     if class_name in options_map and key == "model_name":


### PR DESCRIPTION
This PR adds support for 50+ models with a standard I/O interface using: https://github.com/BerriAI/litellm/
LiteLLM is a lightweight library that allows you to use any LLM as a drop in replacement for gpt-3.5-turbo 

`ChatLiteLLM()` is integrated into langchain and allows you to call all models using the `ChatOpenAI` I/O interface 
https://python.langchain.com/docs/integrations/chat/litellm

Here's an example of how to use ChatLiteLLM()
```python
ChatLiteLLM(model="gpt-3.5-turbo")
ChatLiteLLM(model="claude-2", temperature=0.3)
ChatLiteLLM(model="command-nightly")
ChatLiteLLM(model="replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1")

```