### PR TITLE
📝 docs(langfuse_integration.mdx): remove reference to troubleshooting section in Langfuse documentation as it is not available

### DIFF
--- a/docs/docs/guides/langfuse_integration.mdx
+++ b/docs/docs/guides/langfuse_integration.mdx
@@ -40,7 +40,7 @@ Langfuse is an open-source tracing and analytics tool designed for LLM applicati
    echo $LANGFLOW_LANGFUSE_PUBLIC_KEY
    ```
 
-3. **Monitor Langflow**: Now, whenever you use Langflow's chat or API, you will be able to see the tracing of your conversations in Langfuse. If you have any issues with the integration, consult the [Langfuse documentation](<link to specific troubleshooting section>) or contact their support.
+3. **Monitor Langflow**: Now, whenever you use Langflow's chat or API, you will be able to see the tracing of your conversations in Langfuse.
 
 That's it! You have successfully integrated Langfuse with Langflow, enhancing observability and debugging capabilities for your LLM application.
 


### PR DESCRIPTION
📝 docs(langfuse_integration.mdx): update step 3 to remove mention of consulting Langfuse documentation or contacting support for integration issues