### PR TITLE
🐛 fix(genericModal/index.tsx): set field_name to the first key of custom_fields object if it is an empty string

### DIFF
--- a/src/frontend/src/modals/genericModal/index.tsx
+++ b/src/frontend/src/modals/genericModal/index.tsx
@@ -109,6 +109,13 @@ export default function GenericModal({
 
     postValidatePrompt(field_name, inputValue, nodeClass!)
       .then((apiReturn) => {
+        // if field_name is an empty string, then we need to set it
+        // to the first key of the custom_fields object
+        if (field_name === "") {
+          field_name = Object.keys(
+            apiReturn.data?.frontend_node?.custom_fields ?? {}
+          )[0];
+        }
         if (apiReturn.data) {
           let inputVariables = apiReturn.data.input_variables ?? [];
           if (inputVariables && inputVariables.length === 0) {
@@ -124,7 +131,7 @@ export default function GenericModal({
               setNodeClass!(apiReturn.data?.frontend_node);
             setModalOpen(closeModal);
             setValue(inputValue);
-            apiReturn.data.frontend_node["template"]["template"]["value"] =
+            apiReturn.data.frontend_node["template"][field_name]["value"] =
               inputValue;
           } else {
             setIsEdit(false);
@@ -138,7 +145,7 @@ export default function GenericModal({
               setNodeClass!(apiReturn.data?.frontend_node);
             setModalOpen(closeModal);
             setValue(inputValue);
-            apiReturn.data.frontend_node["template"]["template"]["value"] =
+            apiReturn.data.frontend_node["template"][field_name]["value"] =
               inputValue;
           }
         } else {

--- a/src/frontend/src/modals/genericModal/index.tsx
+++ b/src/frontend/src/modals/genericModal/index.tsx
@@ -112,9 +112,12 @@ export default function GenericModal({
         // if field_name is an empty string, then we need to set it
         // to the first key of the custom_fields object
         if (field_name === "") {
-          field_name = Object.keys(
-            apiReturn.data?.frontend_node?.custom_fields ?? {}
-          )[0];
+          console.log(apiReturn.data?.frontend_node?.custom_fields);
+          field_name = Array.isArray(
+            apiReturn.data?.frontend_node?.custom_fields?.[""]
+          )
+            ? apiReturn.data?.frontend_node?.custom_fields?.[""][0] ?? ""
+            : apiReturn.data?.frontend_node?.custom_fields?.[""] ?? "";
         }
         if (apiReturn.data) {
           let inputVariables = apiReturn.data.input_variables ?? [];
@@ -131,8 +134,10 @@ export default function GenericModal({
               setNodeClass!(apiReturn.data?.frontend_node);
             setModalOpen(closeModal);
             setValue(inputValue);
-            apiReturn.data.frontend_node["template"][field_name]["value"] =
-              inputValue;
+            if (field_name !== "") {
+              apiReturn.data.frontend_node["template"][field_name]["value"] =
+                inputValue;
+            }
           } else {
             setIsEdit(false);
             setSuccessData({
@@ -145,8 +150,10 @@ export default function GenericModal({
               setNodeClass!(apiReturn.data?.frontend_node);
             setModalOpen(closeModal);
             setValue(inputValue);
-            apiReturn.data.frontend_node["template"][field_name]["value"] =
-              inputValue;
+            if (field_name !== "") {
+              apiReturn.data.frontend_node["template"][field_name]["value"] =
+                inputValue;
+            }
           }
         } else {
           setIsEdit(true);

--- a/src/frontend/src/types/api/index.ts
+++ b/src/frontend/src/types/api/index.ts
@@ -7,6 +7,11 @@ export type APITemplateType = {
   variable: TemplateVariableType;
   [key: string]: TemplateVariableType;
 };
+
+export type CustomFieldsType = {
+  [key: string]: Array<string>;
+};
+
 export type APIClassType = {
   base_classes: Array<string>;
   description: string;
@@ -14,10 +19,17 @@ export type APIClassType = {
   display_name: string;
   input_types?: Array<string>;
   output_types?: Array<string>;
+  custom_fields?: CustomFieldsType;
   beta?: boolean;
   documentation: string;
   error?: string;
-  [key: string]: Array<string> | string | APITemplateType | boolean | undefined;
+  [key: string]:
+    | Array<string>
+    | string
+    | APITemplateType
+    | CustomFieldsType
+    | boolean
+    | undefined;
 };
 
 export type TemplateVariableType = {


### PR DESCRIPTION
🐛 fix(genericModal/index.tsx): update template value based on field_name instead of hardcoding "template"
✨ feat(api/index.ts): add CustomFieldsType to represent custom fields in APIClassType