### PR TITLE
Fix: missing numexpr when using poetry to run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ langfuse = "^1.0.13"
 pillow = "^10.0.0"
 metal-sdk = "^2.2.0"
 markupsafe = "^2.1.3"
+numexpr = "^2.8.6"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This is to fix the issue: #1039 

Add poetry dependency for numexpr.