### PR TITLE
🐛 fix(base.py): handle import errors when importing utilities to prevent application crashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ format:
 	cd src/frontend && npm run format
 
 lint:
+	make install_backend
 	poetry run mypy src/backend/langflow
 	poetry run black . --check
 	poetry run ruff . --fix

--- a/src/backend/langflow/interface/utilities/base.py
+++ b/src/backend/langflow/interface/utilities/base.py
@@ -28,10 +28,14 @@ class UtilityCreator(LangChainTypeCreator):
         """
         if self.type_dict is None:
             settings_service = get_settings_service()
-            self.type_dict = {
-                utility_name: import_class(f"langchain.utilities.{utility_name}")
-                for utility_name in utilities.__all__
-            }
+            self.type_dict = {}
+            for utility_name in utilities.__all__:
+                try:
+                    imported = import_class(f"langchain.utilities.{utility_name}")
+                    self.type_dict[utility_name] = imported
+                except Exception:
+                    pass
+
             self.type_dict["SQLDatabase"] = utilities.SQLDatabase
             # Filter according to settings.utilities
             self.type_dict = {


### PR DESCRIPTION
The code now handles import errors when importing utilities from the `langchain.utilities` module. If an import error occurs, the utility is skipped and not added to the `type_dict` dictionary. This prevents the application from crashing when encountering an invalid or missing utility.