### PR TITLE
modify get_current_user to accept api_key as authentication method

### DIFF
--- a/src/backend/langflow/api/v1/chat.py
+++ b/src/backend/langflow/api/v1/chat.py
@@ -2,7 +2,6 @@ from fastapi import (
     APIRouter,
     Depends,
     HTTPException,
-    Query,
     WebSocket,
     WebSocketException,
     status,
@@ -11,8 +10,9 @@ from fastapi.responses import StreamingResponse
 from langflow.api.utils import build_input_keys_response
 from langflow.api.v1.schemas import BuildStatus, BuiltResponse, InitResponse, StreamData
 
+from langflow.services.database.models.user.user import User
 from langflow.graph.graph.base import Graph
-from langflow.services.auth.utils import get_current_active_user, get_current_user
+from langflow.services.auth.utils import get_current_active_user
 from langflow.services.cache.utils import update_build_status
 from loguru import logger
 from langflow.services.getters import get_chat_service, get_session, get_cache_service
@@ -28,14 +28,13 @@ router = APIRouter(tags=["Chat"])
 async def chat(
     client_id: str,
     websocket: WebSocket,
-    token: str = Query(...),
     db: Session = Depends(get_session),
     chat_service: "ChatService" = Depends(get_chat_service),
+    user: User = Depends(get_current_active_user),
 ):
     """Websocket endpoint for chat."""
     try:
         await websocket.accept()
-        user = await get_current_user(token, db)
         if not user:
             await websocket.close(
                 code=status.WS_1008_POLICY_VIOLATION, reason="Unauthorized"

--- a/src/backend/langflow/services/auth/utils.py
+++ b/src/backend/langflow/services/auth/utils.py
@@ -70,13 +70,12 @@ async def api_key_security(
 
 
 async def get_current_user(
-    request: Request,
+    token: str = Security(oauth2_login),
     query_param: str = Security(api_key_query),
     header_param: str = Security(api_key_header),
     db: Session = Depends(get_session),
 ) -> User:
     try:
-        token = oauth2_login(request)
         return await get_current_user_by_jwt(token, db)
     except HTTPException:
         user = await api_key_security(query_param, header_param, db)


### PR DESCRIPTION
Regarding this [feature request](https://github.com/logspace-ai/langflow/issues/1100#issuecomment-1787188525), I've created this PR. It lets the users call all the endpoints with their `api_key`. I updated the `get_current_user` function, and it checks the request headers to see whether the `Bearer token` is provided or `api_key`. Otherwise, it raise 401. 