### PR TITLE
Allow users to use dark mode

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -31,7 +31,7 @@ module.exports = {
             [
               remarkCodeHike,
               {
-                theme: "github-light",
+                theme: "github-dark",
                 showCopyButton: true,
                 lineNumbers: true,
               },

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -112,8 +112,10 @@ module.exports = {
       },
       colorMode: {
         defaultMode: "light",
-        disableSwitch: true,
-        respectPrefersColorScheme: false,
+        /* Allow users to chose light or dark mode. */
+        disableSwitch: false,
+        /* Respect user preferences, such as low light mode in the evening */
+        respectPrefersColorScheme: true,
       },
       announcementBar: {
         content:


### PR DESCRIPTION
Related to #1115 

It is nice to allow users to choose light or dark mode based on their own needs, such as sensitivity to bright light.