### PR TITLE
Fix components link (Python integrations documentation)

### DIFF
--- a/docs/docs/guidelines/components.mdx
+++ b/docs/docs/guidelines/components.mdx
@@ -5,7 +5,7 @@ import ReactPlayer from "react-player";
 
 # Component
 
-Components are the building blocks of the flows. They are made of inputs, outputs, and parameters that define their functionality, providing a convenient and straightforward way to compose LLM-based applications. Learn more about components and how they work in the LangChain [documentation](https://docs.langchain.com/docs/category/components) section.
+Components are the building blocks of the flows. They are made of inputs, outputs, and parameters that define their functionality, providing a convenient and straightforward way to compose LLM-based applications. Learn more about components and how they work in the LangChain [documentation](https://python.langchain.com/docs/integrations/components) section.
 
 ### Component's Features
 


### PR DESCRIPTION
The LangFlow Components documentation contains a broken link to the LangChain components documentation. This PR fixes the link to point to the LangChain integrations/components docs.