### PR TITLE
Fix: Avoid fix_memory_inputs when langchain_object is instance of AgentExecutor

### DIFF
--- a/src/backend/langflow/processing/process.py
+++ b/src/backend/langflow/processing/process.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from langchain.agents import AgentExecutor
 from langchain.schema import AgentAction
 from langflow.interface.run import (
     build_sorted_vertices,
@@ -70,7 +71,11 @@ def get_result_and_thought(langchain_object: Any, inputs: dict):
         if hasattr(langchain_object, "return_intermediate_steps"):
             langchain_object.return_intermediate_steps = False
 
-        fix_memory_inputs(langchain_object)
+        try:
+            if not isinstance(langchain_object, AgentExecutor):
+                fix_memory_inputs(langchain_object)
+        except Exception as exc:
+            logger.error(f"Error fixing memory inputs: {exc}")
 
         try:
             output = langchain_object(inputs, return_only_outputs=True)


### PR DESCRIPTION
This is to fix the following issue:

- When process a flow using endpoint api, `memory_key` alternates between `history` and `chat_history`, causing success and failure to alternate. This occurs when the langchain_object is an instance of AgentExecutor  

This is similiar to https://github.com/logspace-ai/langflow/commit/67f8bb9dab66151083743e7a2d5833d9d0e69b22