### PR TITLE
Remove to_dict method in favor or pydantic implementation

### DIFF
--- a/src/backend/langflow/interface/types.py
+++ b/src/backend/langflow/interface/types.py
@@ -8,8 +8,6 @@ from uuid import UUID
 
 from cachetools import LRUCache, cached
 from fastapi import HTTPException
-from loguru import logger
-
 from langflow.interface.agents.base import agent_creator
 from langflow.interface.chains.base import chain_creator
 from langflow.interface.custom.custom_component import CustomComponent
@@ -33,6 +31,7 @@ from langflow.template.field.base import TemplateField
 from langflow.template.frontend_node.constants import CLASSES_TO_REMOVE
 from langflow.template.frontend_node.custom_components import CustomComponentFrontendNode
 from langflow.utils.util import get_base_classes
+from loguru import logger
 
 
 # Used to get the base_classes list
@@ -130,7 +129,7 @@ def add_new_custom_field(
         display_name=display_name,
         **field_config,
     )
-    template.get("template")[field_name] = new_field.to_dict()
+    template.get("template")[field_name] = new_field.model_dump(by_alias=True, exclude_none=True)
     template.get("custom_fields")[field_name] = None
 
     return template

--- a/src/backend/langflow/template/field/base.py
+++ b/src/backend/langflow/template/field/base.py
@@ -1,11 +1,11 @@
-from abc import ABC
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
-from pydantic import BaseModel, Field, field_serializer, model_serializer
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
 
-class TemplateFieldCreator(BaseModel, ABC):
-    field_type: str = Field(default="str", alias="type")
+class TemplateField(BaseModel):
+    model_config = ConfigDict()
+    field_type: str = Field(default="str", serialization_alias="type")
     """The type of field this is. Default is a string."""
 
     required: bool = False
@@ -14,7 +14,7 @@ class TemplateFieldCreator(BaseModel, ABC):
     placeholder: str = ""
     """A placeholder string for the field. Default is an empty string."""
 
-    is_list: bool = Field(default=False, alias="list")
+    is_list: bool = Field(default=False, serialization_alias="list")
     """Defines if the field is a list. Default is False."""
 
     show: bool = True
@@ -23,19 +23,19 @@ class TemplateFieldCreator(BaseModel, ABC):
     multiline: bool = False
     """Defines if the field will allow the user to open a text editor. Default is False."""
 
-    value: Any = None
+    value: Any = ""
     """The value of the field. Default is None."""
 
-    file_types: list[str] = Field(default=[], alias="fileTypes")
+    file_types: list[str] = Field(default=[], serialization_alias="fileTypes")
     """List of file types associated with the field. Default is an empty list. (duplicate)"""
 
-    file_path: Union[str, None] = None
+    file_path: Optional[str] = ""
     """The file path of the field if it is a file. Defaults to None."""
 
     password: bool = False
     """Specifies if the field is a password. Defaults to False."""
 
-    options: list[str] = None
+    options: Optional[list[str]] = None
     """List of options for the field. Only used when is_list=True. Default is an empty list."""
 
     name: str = ""
@@ -59,31 +59,11 @@ class TemplateFieldCreator(BaseModel, ABC):
     refresh: Optional[bool] = None
     """Specifies if the field should be refreshed. Defaults to False."""
 
-    @model_serializer(mode="wrap")
-    def serialize_model(self, handler):
-        # This will be the result of model_dump or dict()
-        # so we need to build a dict to return
-        result = handler(self)
-        result["value"] = self.value
-        return result
-
-
-
-        # for key in list(result.keys()):
-        #     if result[key] is None or result[key] == [] and key != "value":
-        #         del result[key]
-        # return result
-
     def to_dict(self):
         return self.model_dump(by_alias=True, exclude_none=True)
-
 
     @field_serializer("file_path")
     def serialize_file_path(self, value):
         if self.field_type == "file":
             return value
-        return None
-
-
-class TemplateField(TemplateFieldCreator):
-    pass
+        return ""

--- a/src/backend/langflow/template/field/base.py
+++ b/src/backend/langflow/template/field/base.py
@@ -1,11 +1,11 @@
 from abc import ABC
 from typing import Any, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_serializer, model_serializer
 
 
 class TemplateFieldCreator(BaseModel, ABC):
-    field_type: str = "str"
+    field_type: str = Field(default="str", alias="type")
     """The type of field this is. Default is a string."""
 
     required: bool = False
@@ -14,7 +14,7 @@ class TemplateFieldCreator(BaseModel, ABC):
     placeholder: str = ""
     """A placeholder string for the field. Default is an empty string."""
 
-    is_list: bool = False
+    is_list: bool = Field(default=False, alias="list")
     """Defines if the field is a list. Default is False."""
 
     show: bool = True
@@ -26,7 +26,7 @@ class TemplateFieldCreator(BaseModel, ABC):
     value: Any = None
     """The value of the field. Default is None."""
 
-    file_types: list[str] = []
+    file_types: list[str] = Field(default=[], alias="fileTypes")
     """List of file types associated with the field. Default is an empty list. (duplicate)"""
 
     file_path: Union[str, None] = None
@@ -35,7 +35,7 @@ class TemplateFieldCreator(BaseModel, ABC):
     password: bool = False
     """Specifies if the field is a password. Defaults to False."""
 
-    options: list[str] = []
+    options: list[str] = None
     """List of options for the field. Only used when is_list=True. Default is an empty list."""
 
     name: str = ""
@@ -47,7 +47,7 @@ class TemplateFieldCreator(BaseModel, ABC):
     advanced: bool = False
     """Specifies if the field will an advanced parameter (hidden). Defaults to False."""
 
-    input_types: list[str] = []
+    input_types: Optional[list[str]] = None
     """List of input types for the handle when the field has more than one type. Default is an empty list."""
 
     dynamic: bool = False
@@ -59,21 +59,30 @@ class TemplateFieldCreator(BaseModel, ABC):
     refresh: Optional[bool] = None
     """Specifies if the field should be refreshed. Defaults to False."""
 
-    def to_dict(self):
-        result = self.model_dump()
-        # Remove key if it is None
-        for key in list(result.keys()):
-            if result[key] is None or result[key] == [] and key != "value":
-                del result[key]
-        result["type"] = result.pop("field_type")
-        result["list"] = result.pop("is_list")
-
-        if result.get("file_types"):
-            result["fileTypes"] = result.pop("file_types")
-
-        if self.field_type == "file":
-            result["file_path"] = self.file_path
+    @model_serializer(mode="wrap")
+    def serialize_model(self, handler):
+        # This will be the result of model_dump or dict()
+        # so we need to build a dict to return
+        result = handler(self)
+        result["value"] = self.value
         return result
+
+
+
+        # for key in list(result.keys()):
+        #     if result[key] is None or result[key] == [] and key != "value":
+        #         del result[key]
+        # return result
+
+    def to_dict(self):
+        return self.model_dump(by_alias=True, exclude_none=True)
+
+
+    @field_serializer("file_path")
+    def serialize_file_path(self, value):
+        if self.field_type == "file":
+            return value
+        return None
 
 
 class TemplateField(TemplateFieldCreator):

--- a/src/backend/langflow/template/frontend_node/agents.py
+++ b/src/backend/langflow/template/frontend_node/agents.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 from langchain.agents import types
-
 from langflow.template.field.base import TemplateField
 from langflow.template.frontend_node.base import FrontendNode
 from langflow.template.template.base import Template
@@ -29,17 +28,17 @@ class SQLAgentNode(FrontendNode):
         type_name="sql_agent",
         fields=[
             TemplateField(
-                field_type="str",
+                field_type="str", # pyright: ignore
                 required=True,
                 placeholder="",
-                is_list=False,
+                is_list=False, # pyright: ignore
                 show=True,
                 multiline=False,
                 value="",
                 name="database_uri",
             ),
             TemplateField(
-                field_type="BaseLanguageModel",
+                field_type="BaseLanguageModel", # pyright: ignore
                 required=True,
                 show=True,
                 name="llm",
@@ -60,14 +59,14 @@ class VectorStoreRouterAgentNode(FrontendNode):
         type_name="vectorstorerouter_agent",
         fields=[
             TemplateField(
-                field_type="VectorStoreRouterToolkit",
+                field_type="VectorStoreRouterToolkit", # pyright: ignore
                 required=True,
                 show=True,
                 name="vectorstoreroutertoolkit",
                 display_name="Vector Store Router Toolkit",
             ),
             TemplateField(
-                field_type="BaseLanguageModel",
+                field_type="BaseLanguageModel", # pyright: ignore
                 required=True,
                 show=True,
                 name="llm",
@@ -88,14 +87,14 @@ class VectorStoreAgentNode(FrontendNode):
         type_name="vectorstore_agent",
         fields=[
             TemplateField(
-                field_type="VectorStoreInfo",
+                field_type="VectorStoreInfo", # pyright: ignore
                 required=True,
                 show=True,
                 name="vectorstoreinfo",
                 display_name="Vector Store Info",
             ),
             TemplateField(
-                field_type="BaseLanguageModel",
+                field_type="BaseLanguageModel", # pyright: ignore
                 required=True,
                 show=True,
                 name="llm",
@@ -116,9 +115,9 @@ class SQLDatabaseNode(FrontendNode):
         type_name="sql_database",
         fields=[
             TemplateField(
-                field_type="str",
+                field_type="str", # pyright: ignore
                 required=True,
-                is_list=False,
+                is_list=False, # pyright: ignore
                 show=True,
                 multiline=False,
                 value="",
@@ -139,15 +138,15 @@ class CSVAgentNode(FrontendNode):
         type_name="csv_agent",
         fields=[
             TemplateField(
-                field_type="file",
+                field_type="file", # pyright: ignore
                 required=True,
                 show=True,
                 name="path",
                 value="",
-                file_types=[".csv"],
+                file_types=[".csv"], # pyright: ignore
             ),
             TemplateField(
-                field_type="BaseLanguageModel",
+                field_type="BaseLanguageModel", # pyright: ignore
                 required=True,
                 show=True,
                 name="llm",
@@ -169,9 +168,9 @@ class InitializeAgentNode(FrontendNode):
         type_name="initialize_agent",
         fields=[
             TemplateField(
-                field_type="str",
+                field_type="str", # pyright: ignore
                 required=True,
-                is_list=True,
+                is_list=True, # pyright: ignore
                 show=True,
                 multiline=False,
                 options=list(NON_CHAT_AGENTS.keys()),
@@ -180,22 +179,22 @@ class InitializeAgentNode(FrontendNode):
                 advanced=False,
             ),
             TemplateField(
-                field_type="BaseChatMemory",
+                field_type="BaseChatMemory", # pyright: ignore
                 required=False,
                 show=True,
                 name="memory",
                 advanced=False,
             ),
             TemplateField(
-                field_type="Tool",
+                field_type="Tool", # pyright: ignore
                 required=True,
                 show=True,
                 name="tools",
-                is_list=True,
+                is_list=True, # pyright: ignore
                 advanced=False,
             ),
             TemplateField(
-                field_type="BaseLanguageModel",
+                field_type="BaseLanguageModel", # pyright: ignore
                 required=True,
                 show=True,
                 name="llm",
@@ -222,13 +221,13 @@ class JsonAgentNode(FrontendNode):
         type_name="json_agent",
         fields=[
             TemplateField(
-                field_type="BaseToolkit",
+                field_type="BaseToolkit", # pyright: ignore
                 required=True,
                 show=True,
                 name="toolkit",
             ),
             TemplateField(
-                field_type="BaseLanguageModel",
+                field_type="BaseLanguageModel", # pyright: ignore
                 required=True,
                 show=True,
                 name="llm",

--- a/src/backend/langflow/template/frontend_node/agents.py
+++ b/src/backend/langflow/template/frontend_node/agents.py
@@ -28,17 +28,17 @@ class SQLAgentNode(FrontendNode):
         type_name="sql_agent",
         fields=[
             TemplateField(
-                field_type="str", # pyright: ignore
+                field_type="str",  # pyright: ignore
                 required=True,
                 placeholder="",
-                is_list=False, # pyright: ignore
+                is_list=False,  # pyright: ignore
                 show=True,
                 multiline=False,
                 value="",
                 name="database_uri",
             ),
             TemplateField(
-                field_type="BaseLanguageModel", # pyright: ignore
+                field_type="BaseLanguageModel",  # pyright: ignore
                 required=True,
                 show=True,
                 name="llm",
@@ -49,9 +49,6 @@ class SQLAgentNode(FrontendNode):
     description: str = """Construct an SQL agent from an LLM and tools."""
     base_classes: list[str] = ["AgentExecutor"]
 
-    def to_dict(self):
-        return super().to_dict()
-
 
 class VectorStoreRouterAgentNode(FrontendNode):
     name: str = "VectorStoreRouterAgent"
@@ -59,14 +56,14 @@ class VectorStoreRouterAgentNode(FrontendNode):
         type_name="vectorstorerouter_agent",
         fields=[
             TemplateField(
-                field_type="VectorStoreRouterToolkit", # pyright: ignore
+                field_type="VectorStoreRouterToolkit",  # pyright: ignore
                 required=True,
                 show=True,
                 name="vectorstoreroutertoolkit",
                 display_name="Vector Store Router Toolkit",
             ),
             TemplateField(
-                field_type="BaseLanguageModel", # pyright: ignore
+                field_type="BaseLanguageModel",  # pyright: ignore
                 required=True,
                 show=True,
                 name="llm",
@@ -77,9 +74,6 @@ class VectorStoreRouterAgentNode(FrontendNode):
     description: str = """Construct an agent from a Vector Store Router."""
     base_classes: list[str] = ["AgentExecutor"]
 
-    def to_dict(self):
-        return super().to_dict()
-
 
 class VectorStoreAgentNode(FrontendNode):
     name: str = "VectorStoreAgent"
@@ -87,14 +81,14 @@ class VectorStoreAgentNode(FrontendNode):
         type_name="vectorstore_agent",
         fields=[
             TemplateField(
-                field_type="VectorStoreInfo", # pyright: ignore
+                field_type="VectorStoreInfo",  # pyright: ignore
                 required=True,
                 show=True,
                 name="vectorstoreinfo",
                 display_name="Vector Store Info",
             ),
             TemplateField(
-                field_type="BaseLanguageModel", # pyright: ignore
+                field_type="BaseLanguageModel",  # pyright: ignore
                 required=True,
                 show=True,
                 name="llm",
@@ -105,9 +99,6 @@ class VectorStoreAgentNode(FrontendNode):
     description: str = """Construct an agent from a Vector Store."""
     base_classes: list[str] = ["AgentExecutor"]
 
-    def to_dict(self):
-        return super().to_dict()
-
 
 class SQLDatabaseNode(FrontendNode):
     name: str = "SQLDatabase"
@@ -115,9 +106,9 @@ class SQLDatabaseNode(FrontendNode):
         type_name="sql_database",
         fields=[
             TemplateField(
-                field_type="str", # pyright: ignore
+                field_type="str",  # pyright: ignore
                 required=True,
-                is_list=False, # pyright: ignore
+                is_list=False,  # pyright: ignore
                 show=True,
                 multiline=False,
                 value="",
@@ -128,9 +119,6 @@ class SQLDatabaseNode(FrontendNode):
     description: str = """SQLAlchemy wrapper around a database."""
     base_classes: list[str] = ["SQLDatabase"]
 
-    def to_dict(self):
-        return super().to_dict()
-
 
 class CSVAgentNode(FrontendNode):
     name: str = "CSVAgent"
@@ -138,15 +126,15 @@ class CSVAgentNode(FrontendNode):
         type_name="csv_agent",
         fields=[
             TemplateField(
-                field_type="file", # pyright: ignore
+                field_type="file",  # pyright: ignore
                 required=True,
                 show=True,
                 name="path",
                 value="",
-                file_types=[".csv"], # pyright: ignore
+                file_types=[".csv"],  # pyright: ignore
             ),
             TemplateField(
-                field_type="BaseLanguageModel", # pyright: ignore
+                field_type="BaseLanguageModel",  # pyright: ignore
                 required=True,
                 show=True,
                 name="llm",
@@ -157,9 +145,6 @@ class CSVAgentNode(FrontendNode):
     description: str = """Construct a CSV agent from a CSV and tools."""
     base_classes: list[str] = ["AgentExecutor"]
 
-    def to_dict(self):
-        return super().to_dict()
-
 
 class InitializeAgentNode(FrontendNode):
     name: str = "AgentInitializer"
@@ -168,9 +153,9 @@ class InitializeAgentNode(FrontendNode):
         type_name="initialize_agent",
         fields=[
             TemplateField(
-                field_type="str", # pyright: ignore
+                field_type="str",  # pyright: ignore
                 required=True,
-                is_list=True, # pyright: ignore
+                is_list=True,  # pyright: ignore
                 show=True,
                 multiline=False,
                 options=list(NON_CHAT_AGENTS.keys()),
@@ -179,22 +164,22 @@ class InitializeAgentNode(FrontendNode):
                 advanced=False,
             ),
             TemplateField(
-                field_type="BaseChatMemory", # pyright: ignore
+                field_type="BaseChatMemory",  # pyright: ignore
                 required=False,
                 show=True,
                 name="memory",
                 advanced=False,
             ),
             TemplateField(
-                field_type="Tool", # pyright: ignore
+                field_type="Tool",  # pyright: ignore
                 required=True,
                 show=True,
                 name="tools",
-                is_list=True, # pyright: ignore
+                is_list=True,  # pyright: ignore
                 advanced=False,
             ),
             TemplateField(
-                field_type="BaseLanguageModel", # pyright: ignore
+                field_type="BaseLanguageModel",  # pyright: ignore
                 required=True,
                 show=True,
                 name="llm",
@@ -205,9 +190,6 @@ class InitializeAgentNode(FrontendNode):
     )
     description: str = """Construct a zero shot agent from an LLM and tools."""
     base_classes: list[str] = ["AgentExecutor", "Callable"]
-
-    def to_dict(self):
-        return super().to_dict()
 
     @staticmethod
     def format_field(field: TemplateField, name: Optional[str] = None) -> None:
@@ -221,13 +203,13 @@ class JsonAgentNode(FrontendNode):
         type_name="json_agent",
         fields=[
             TemplateField(
-                field_type="BaseToolkit", # pyright: ignore
+                field_type="BaseToolkit",  # pyright: ignore
                 required=True,
                 show=True,
                 name="toolkit",
             ),
             TemplateField(
-                field_type="BaseLanguageModel", # pyright: ignore
+                field_type="BaseLanguageModel",  # pyright: ignore
                 required=True,
                 show=True,
                 name="llm",
@@ -237,6 +219,3 @@ class JsonAgentNode(FrontendNode):
     )
     description: str = """Construct a json agent from an LLM and tools."""
     base_classes: list[str] = ["AgentExecutor"]
-
-    def to_dict(self):
-        return super().to_dict()

--- a/src/backend/langflow/template/frontend_node/base.py
+++ b/src/backend/langflow/template/frontend_node/base.py
@@ -3,8 +3,7 @@ from collections import defaultdict
 from typing import ClassVar, Dict, List, Optional
 
 from langflow.template.field.base import TemplateField
-from langflow.template.frontend_node.constants import (CLASSES_TO_REMOVE,
-                                                       FORCE_SHOW_FIELDS)
+from langflow.template.frontend_node.constants import CLASSES_TO_REMOVE, FORCE_SHOW_FIELDS
 from langflow.template.frontend_node.formatter import field_formatters
 from langflow.template.template.base import Template
 from langflow.utils import constants
@@ -76,15 +75,16 @@ class FrontendNode(BaseModel):
 
         return display_name or self.name
 
-
     @model_serializer(mode="wrap")
     def serialize(self, handler):
         result = handler(self)
-        result["template"] = self.template.to_dict(self.format_field)
+        if hasattr(self, "template") and hasattr(self.template, "to_dict"):
+            result["template"] = self.template.to_dict(self.format_field)
         name = result.pop("name")
 
         return {name: result}
 
+    # For backwards compatibility
     def to_dict(self) -> dict:
         """Returns a dict representation of the frontend node."""
 

--- a/src/backend/langflow/template/frontend_node/chains.py
+++ b/src/backend/langflow/template/frontend_node/chains.py
@@ -247,9 +247,6 @@ class CombineDocsChainNode(FrontendNode):
     description: str = """Load question answering chain."""
     base_classes: list[str] = ["BaseCombineDocumentsChain", "Callable"]
 
-    def to_dict(self):
-        return super().to_dict()
-
     @staticmethod
     def format_field(field: TemplateField, name: Optional[str] = None) -> None:
         # do nothing and don't return anything

--- a/src/backend/langflow/template/frontend_node/custom_components.py
+++ b/src/backend/langflow/template/frontend_node/custom_components.py
@@ -66,6 +66,3 @@ class CustomComponentFrontendNode(FrontendNode):
     )
     description: Optional[str] = None
     base_classes: list[str] = []
-
-    def to_dict(self):
-        return super().to_dict()

--- a/src/backend/langflow/template/frontend_node/custom_components.py
+++ b/src/backend/langflow/template/frontend_node/custom_components.py
@@ -3,6 +3,7 @@ from typing import Optional
 from langflow.template.field.base import TemplateField
 from langflow.template.frontend_node.base import FrontendNode
 from langflow.template.template.base import Template
+from pydantic import field_serializer
 
 DEFAULT_CUSTOM_COMPONENT_CODE = """from langflow import CustomComponent
 from typing import Optional, List, Dict, Union
@@ -66,3 +67,9 @@ class CustomComponentFrontendNode(FrontendNode):
     )
     description: Optional[str] = None
     base_classes: list[str] = []
+
+    @field_serializer("display_name")
+    def process_display_name(self, display_name: str) -> str:
+        """Sets the display name of the frontend node."""
+
+        return display_name

--- a/src/backend/langflow/template/frontend_node/formatter/field_formatters.py
+++ b/src/backend/langflow/template/frontend_node/formatter/field_formatters.py
@@ -129,7 +129,7 @@ class MultilineFieldFormatter(FieldFormatter):
 
 class DefaultValueFormatter(FieldFormatter):
     def format(self, field: TemplateField, name: Optional[str] = None) -> None:
-        value = field.to_dict()
+        value = field.model_dump(by_alias=True, exclude_none=True)
         if "default" in value:
             field.value = value["default"]
 
@@ -144,7 +144,7 @@ class HeadersDefaultValueFormatter(FieldFormatter):
 class DictCodeFileFormatter(FieldFormatter):
     def format(self, field: TemplateField, name: Optional[str] = None) -> None:
         key = field.name
-        value = field.to_dict()
+        value = field.model_dump(by_alias=True, exclude_none=True)
         _type = value["type"]
         if "dict" in _type.lower() and key == "dict_":
             field.field_type = "file"

--- a/src/backend/langflow/template/frontend_node/prompts.py
+++ b/src/backend/langflow/template/frontend_node/prompts.py
@@ -1,14 +1,9 @@
 from typing import Optional
 
 from langchain.agents.mrkl import prompt
-
-from langflow.template.frontend_node.constants import (
-    DEFAULT_PROMPT,
-    HUMAN_PROMPT,
-    SYSTEM_PROMPT,
-)
 from langflow.template.field.base import TemplateField
 from langflow.template.frontend_node.base import FrontendNode
+from langflow.template.frontend_node.constants import DEFAULT_PROMPT, HUMAN_PROMPT, SYSTEM_PROMPT
 from langflow.template.template.base import Template
 
 
@@ -50,9 +45,6 @@ class PromptTemplateNode(FrontendNode):
     description: str
     base_classes: list[str] = ["BasePromptTemplate"]
 
-    def to_dict(self):
-        return super().to_dict()
-
     @staticmethod
     def format_field(field: TemplateField, name: Optional[str] = None) -> None:
         FrontendNode.format_field(field, name)
@@ -65,9 +57,6 @@ class BasePromptFrontendNode(FrontendNode):
     template: Template
     description: str
     base_classes: list[str]
-
-    def to_dict(self):
-        return super().to_dict()
 
 
 class ZeroShotPromptNode(BasePromptFrontendNode):
@@ -109,9 +98,6 @@ class ZeroShotPromptNode(BasePromptFrontendNode):
     )
     description: str = "Prompt template for Zero Shot Agent."
     base_classes: list[str] = ["BasePromptTemplate"]
-
-    def to_dict(self):
-        return super().to_dict()
 
     @staticmethod
     def format_field(field: TemplateField, name: Optional[str] = None) -> None:

--- a/src/backend/langflow/template/frontend_node/tools.py
+++ b/src/backend/langflow/template/frontend_node/tools.py
@@ -1,9 +1,7 @@
 from langflow.template.field.base import TemplateField
 from langflow.template.frontend_node.base import FrontendNode
 from langflow.template.template.base import Template
-from langflow.utils.constants import (
-    DEFAULT_PYTHON_FUNCTION,
-)
+from langflow.utils.constants import DEFAULT_PYTHON_FUNCTION
 
 
 class ToolNode(FrontendNode):
@@ -56,9 +54,6 @@ class ToolNode(FrontendNode):
     )
     description: str = "Converts a chain, agent or function into a tool."
     base_classes: list[str] = ["Tool", "BaseTool"]
-
-    def to_dict(self):
-        return super().to_dict()
 
 
 class PythonFunctionToolNode(FrontendNode):
@@ -113,9 +108,6 @@ class PythonFunctionToolNode(FrontendNode):
     description: str = "Python function to be executed."
     base_classes: list[str] = ["BaseTool", "Tool"]
 
-    def to_dict(self):
-        return super().to_dict()
-
 
 class PythonFunctionNode(FrontendNode):
     name: str = "PythonFunction"
@@ -136,6 +128,3 @@ class PythonFunctionNode(FrontendNode):
     )
     description: str = "Python function to be executed."
     base_classes: list[str] = ["Callable"]
-
-    def to_dict(self):
-        return super().to_dict()

--- a/src/backend/langflow/template/template/base.py
+++ b/src/backend/langflow/template/template/base.py
@@ -27,15 +27,14 @@ class Template(BaseModel):
     def serialize_model(self, handler):
         result = handler(self)
         for field in self.fields:
-            result[field.name] = field.to_dict()
+            result[field.name] = field.model_dump(by_alias=True, exclude_none=True)
         result["_type"] = result.pop("type_name")
         return result
 
+    # For backwards compatibility
     def to_dict(self, format_field_func=None):
         self.process_fields(format_field_func)
         self.sort_fields()
-        # result = {field.name: field.to_dict() for field in self.fields}
-        # result["_type"] = self.type_name  # type: ignore
         return self.model_dump(by_alias=True, exclude_none=True, exclude={"fields"})
 
     def add_field(self, field: TemplateField) -> None:

--- a/tests/test_agents_template.py
+++ b/tests/test_agents_template.py
@@ -28,6 +28,8 @@ def test_zero_shot_agent(client: TestClient, logged_in_headers):
         "list": True,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
+        "value": None,
     }
 
     # Additional assertions for other template variables
@@ -43,6 +45,8 @@ def test_zero_shot_agent(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
+        "value": None,
     }
     assert template["llm"] == {
         "required": True,
@@ -56,6 +60,8 @@ def test_zero_shot_agent(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
+        "value": None,
     }
     assert template["output_parser"] == {
         "required": False,
@@ -69,6 +75,8 @@ def test_zero_shot_agent(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
+        "value": None,
     }
     assert template["input_variables"] == {
         "required": False,
@@ -82,6 +90,8 @@ def test_zero_shot_agent(client: TestClient, logged_in_headers):
         "list": True,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
+        "value": None,
     }
     assert template["prefix"] == {
         "required": False,
@@ -96,6 +106,7 @@ def test_zero_shot_agent(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["suffix"] == {
         "required": False,
@@ -110,6 +121,7 @@ def test_zero_shot_agent(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
 
 
@@ -135,6 +147,9 @@ def test_json_agent(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "file_path": "",
+        "fileTypes": [],
+        "value": "",
     }
     assert template["llm"] == {
         "required": True,
@@ -149,6 +164,9 @@ def test_json_agent(client: TestClient, logged_in_headers):
         "advanced": False,
         "display_name": "LLM",
         "info": "",
+        "file_path": "",
+        "fileTypes": [],
+        "value": "",
     }
 
 
@@ -174,7 +192,7 @@ def test_csv_agent(client: TestClient, logged_in_headers):
         "name": "path",
         "type": "file",
         "list": False,
-        "file_path": None,
+        "file_path": "",
         "advanced": False,
         "info": "",
     }
@@ -191,4 +209,7 @@ def test_csv_agent(client: TestClient, logged_in_headers):
         "advanced": False,
         "display_name": "LLM",
         "info": "",
+        "file_path": "",
+        "fileTypes": [],
+        "value": "",
     }

--- a/tests/test_agents_template.py
+++ b/tests/test_agents_template.py
@@ -29,7 +29,6 @@ def test_zero_shot_agent(client: TestClient, logged_in_headers):
         "advanced": False,
         "info": "",
         "fileTypes": [],
-        "value": None,
     }
 
     # Additional assertions for other template variables
@@ -46,7 +45,6 @@ def test_zero_shot_agent(client: TestClient, logged_in_headers):
         "advanced": False,
         "info": "",
         "fileTypes": [],
-        "value": None,
     }
     assert template["llm"] == {
         "required": True,
@@ -61,7 +59,6 @@ def test_zero_shot_agent(client: TestClient, logged_in_headers):
         "advanced": False,
         "info": "",
         "fileTypes": [],
-        "value": None,
     }
     assert template["output_parser"] == {
         "required": False,
@@ -76,7 +73,6 @@ def test_zero_shot_agent(client: TestClient, logged_in_headers):
         "advanced": False,
         "info": "",
         "fileTypes": [],
-        "value": None,
     }
     assert template["input_variables"] == {
         "required": False,
@@ -91,7 +87,6 @@ def test_zero_shot_agent(client: TestClient, logged_in_headers):
         "advanced": False,
         "info": "",
         "fileTypes": [],
-        "value": None,
     }
     assert template["prefix"] == {
         "required": False,

--- a/tests/test_chains_template.py
+++ b/tests/test_chains_template.py
@@ -35,6 +35,7 @@ def test_llm_checker_chain(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["_type"] == "LLMCheckerChain"
 
@@ -69,6 +70,7 @@ def test_llm_math_chain(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["verbose"] == {
         "required": False,
@@ -83,6 +85,7 @@ def test_llm_math_chain(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": True,
         "info": "",
+        "fileTypes": [],
     }
     assert template["llm"] == {
         "required": True,
@@ -96,6 +99,7 @@ def test_llm_math_chain(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["input_key"] == {
         "required": True,
@@ -110,6 +114,7 @@ def test_llm_math_chain(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": True,
         "info": "",
+        "fileTypes": [],
     }
     assert template["output_key"] == {
         "required": True,
@@ -124,6 +129,7 @@ def test_llm_math_chain(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": True,
         "info": "",
+        "fileTypes": [],
     }
     assert template["_type"] == "LLMMathChain"
 
@@ -163,6 +169,9 @@ def test_series_character_chain(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
+        "file_path": "",
+        "value": "",
     }
     assert template["character"] == {
         "required": True,
@@ -176,6 +185,9 @@ def test_series_character_chain(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
+        "file_path": "",
+        "value": "",
     }
     assert template["series"] == {
         "required": True,
@@ -189,6 +201,9 @@ def test_series_character_chain(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
+        "file_path": "",
+        "value": "",
     }
     assert template["_type"] == "SeriesCharacterChain"
 
@@ -232,6 +247,9 @@ def test_mid_journey_prompt_chain(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "file_path": "",
+        "fileTypes": [],
+        "value": "",
     }
     # Test the description object
     assert chain["description"] == "MidJourneyPromptChain is a chain you can use to generate new MidJourney prompts."
@@ -270,6 +288,9 @@ def test_time_travel_guide_chain(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "file_path": "",
+        "fileTypes": [],
+        "value": "",
     }
     assert template["memory"] == {
         "required": False,
@@ -283,6 +304,9 @@ def test_time_travel_guide_chain(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "file_path": "",
+        "fileTypes": [],
+        "value": "",
     }
 
     assert chain["description"] == "Time travel guide chain."

--- a/tests/test_frontend_nodes.py
+++ b/tests/test_frontend_nodes.py
@@ -31,9 +31,9 @@ def test_template_field_defaults(sample_template_field: TemplateField):
     assert sample_template_field.is_list is False
     assert sample_template_field.show is True
     assert sample_template_field.multiline is False
-    assert sample_template_field.value is None
+    assert sample_template_field.value == ""
     assert sample_template_field.file_types == []
-    assert sample_template_field.file_path is None
+    assert sample_template_field.file_path == ""
     assert sample_template_field.password is False
     assert sample_template_field.name == "test_field"
 

--- a/tests/test_llms_template.py
+++ b/tests/test_llms_template.py
@@ -22,6 +22,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["verbose"] == {
         "required": False,
@@ -35,6 +36,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["client"] == {
         "required": False,
@@ -48,6 +50,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["model_name"] == {
         "required": False,
@@ -69,6 +72,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": True,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     # Add more assertions for other properties here
     assert template["temperature"] == {
@@ -84,6 +88,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["max_tokens"] == {
         "required": False,
@@ -98,6 +103,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["top_p"] == {
         "required": False,
@@ -112,6 +118,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["frequency_penalty"] == {
         "required": False,
@@ -126,6 +133,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["presence_penalty"] == {
         "required": False,
@@ -140,6 +148,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["n"] == {
         "required": False,
@@ -154,6 +163,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["best_of"] == {
         "required": False,
@@ -168,6 +178,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["model_kwargs"] == {
         "required": False,
@@ -181,6 +192,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": True,
         "info": "",
+        "fileTypes": [],
     }
     assert template["openai_api_key"] == {
         "required": False,
@@ -196,6 +208,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["batch_size"] == {
         "required": False,
@@ -210,6 +223,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["request_timeout"] == {
         "required": False,
@@ -223,6 +237,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["logit_bias"] == {
         "required": False,
@@ -236,6 +251,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["max_retries"] == {
         "required": False,
@@ -250,6 +266,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["streaming"] == {
         "required": False,
@@ -264,6 +281,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
 
 
@@ -289,6 +307,7 @@ def test_chat_open_ai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["client"] == {
         "required": False,
@@ -302,6 +321,7 @@ def test_chat_open_ai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["model_name"] == {
         "required": False,
@@ -324,6 +344,7 @@ def test_chat_open_ai(client: TestClient, logged_in_headers):
         "list": True,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["temperature"] == {
         "required": False,
@@ -338,6 +359,7 @@ def test_chat_open_ai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["model_kwargs"] == {
         "required": False,
@@ -351,6 +373,7 @@ def test_chat_open_ai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": True,
         "info": "",
+        "fileTypes": [],
     }
     assert template["openai_api_key"] == {
         "required": False,
@@ -366,6 +389,7 @@ def test_chat_open_ai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["request_timeout"] == {
         "required": False,
@@ -379,6 +403,7 @@ def test_chat_open_ai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["max_retries"] == {
         "required": False,
@@ -393,6 +418,7 @@ def test_chat_open_ai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["streaming"] == {
         "required": False,
@@ -407,6 +433,7 @@ def test_chat_open_ai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["n"] == {
         "required": False,
@@ -421,6 +448,7 @@ def test_chat_open_ai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
 
     assert template["max_tokens"] == {
@@ -435,6 +463,7 @@ def test_chat_open_ai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
     assert template["_type"] == "ChatOpenAI"
     assert (

--- a/tests/test_prompts_template.py
+++ b/tests/test_prompts_template.py
@@ -31,6 +31,7 @@ def test_prompt_template(client: TestClient, logged_in_headers):
         "list": True,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
 
     assert template["output_parser"] == {
@@ -45,6 +46,7 @@ def test_prompt_template(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
 
     assert template["partial_variables"] == {
@@ -59,6 +61,7 @@ def test_prompt_template(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
 
     assert template["template"] == {
@@ -73,6 +76,7 @@ def test_prompt_template(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
 
     assert template["template_format"] == {
@@ -88,6 +92,7 @@ def test_prompt_template(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }
 
     assert template["validate_template"] == {
@@ -103,4 +108,5 @@ def test_prompt_template(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "fileTypes": [],
     }


### PR DESCRIPTION
This pull request refactors the code to use model serialization in the Template and FrontendNode classes, improving performance and maintainability. The code is also refactored to remove unused to_dict() methods. Finally, the template files are updated with the new fileTypes field. This PR aims to enhance the overall quality and functionality of the codebase.