### PR TITLE
Add RangeSpec class and functionality in the UI

### DIFF
--- a/docs/docs/components/custom.mdx
+++ b/docs/docs/components/custom.mdx
@@ -73,7 +73,7 @@ The CustomComponent class serves as the foundation for creating custom component
   | _`required: bool`_         | Makes the field required.                                                                                                                                                                                                                                                   |
   | _`info: str`_              | Adds a tooltip to the field.                                                                                                                                                                                                                                                |
   | _`file_types: List[str]`_  | This is a requirement if the _`field_type`_ is _file_. Defines which file types will be accepted. For example, _json_, _yaml_ or _yml_.                                                                                                                                     |
-
+  | _`range_spec: langflow.field_typing.RangeSpec`_ | This is a requirement if the _`field_type`_ is _`float`_. Defines the range of values accepted and the step size. If none is defined, the default is _`[-1, 1, 0.1]`_.                                                                                                     |
 - The CustomComponent class also provides helpful methods for specific tasks (e.g., to load and use other flows from the Langflow platform):
 
   | Method Name    | Description                                                         |

--- a/src/backend/langflow/field_typing/__init__.py
+++ b/src/backend/langflow/field_typing/__init__.py
@@ -22,6 +22,7 @@ from .constants import (
     Tool,
     VectorStore,
 )
+from .range_spec import RangeSpec
 
 __all__ = [
     "NestedDict",
@@ -46,4 +47,5 @@ __all__ = [
     "BasePromptTemplate",
     "ChatPromptTemplate",
     "Prompt",
+    "RangeSpec",
 ]

--- a/src/backend/langflow/field_typing/range_spec.py
+++ b/src/backend/langflow/field_typing/range_spec.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel, field_validator
+
+
+class RangeSpec(BaseModel):
+    min: float = -1.0
+    max: float = 1.0
+    step: float = 0.1
+
+    @field_validator("max")
+    @classmethod
+    def max_must_be_greater_than_min(cls, v, values, **kwargs):
+        if "min" in values.data and v <= values.data["min"]:
+            raise ValueError("max must be greater than min")
+        return v
+
+    @field_validator("step")
+    @classmethod
+    def step_must_be_positive(cls, v):
+        if v <= 0:
+            raise ValueError("step must be positive")
+        return v

--- a/src/backend/langflow/interface/types.py
+++ b/src/backend/langflow/interface/types.py
@@ -10,6 +10,7 @@ from cachetools import LRUCache, cached
 from fastapi import HTTPException
 from loguru import logger
 
+from langflow.field_typing.range_spec import RangeSpec
 from langflow.interface.agents.base import agent_creator
 from langflow.interface.chains.base import chain_creator
 from langflow.interface.custom.custom_component import CustomComponent
@@ -254,6 +255,11 @@ def update_field_dict(field_dict):
 
     if "value" in field_dict and callable(field_dict["value"]):
         field_dict["value"] = field_dict["value"](field_dict.get("options", []))
+        field_dict["refresh"] = True
+
+    # Let's check if "range_spec" is a RangeSpec object
+    if "range_spec" in field_dict and isinstance(field_dict["range_spec"], RangeSpec):
+        field_dict["range_spec"] = field_dict["range_spec"].model_dump()
         field_dict["refresh"] = True
 
 

--- a/src/backend/langflow/interface/types.py
+++ b/src/backend/langflow/interface/types.py
@@ -258,8 +258,8 @@ def update_field_dict(field_dict):
         field_dict["refresh"] = True
 
     # Let's check if "range_spec" is a RangeSpec object
-    if "range_spec" in field_dict and isinstance(field_dict["range_spec"], RangeSpec):
-        field_dict["range_spec"] = field_dict["range_spec"].model_dump()
+    if "rangeSpec" in field_dict and isinstance(field_dict["rangeSpec"], RangeSpec):
+        field_dict["rangeSpec"] = field_dict["rangeSpec"].model_dump()
 
 
 def add_extra_fields(frontend_node, field_config, function_args):

--- a/src/backend/langflow/interface/types.py
+++ b/src/backend/langflow/interface/types.py
@@ -260,7 +260,6 @@ def update_field_dict(field_dict):
     # Let's check if "range_spec" is a RangeSpec object
     if "range_spec" in field_dict and isinstance(field_dict["range_spec"], RangeSpec):
         field_dict["range_spec"] = field_dict["range_spec"].model_dump()
-        field_dict["refresh"] = True
 
 
 def add_extra_fields(frontend_node, field_config, function_args):

--- a/src/backend/langflow/template/field/base.py
+++ b/src/backend/langflow/template/field/base.py
@@ -3,6 +3,8 @@ from typing import Any, Optional, Union
 
 from pydantic import BaseModel
 
+from langflow.field_typing.range_spec import RangeSpec
+
 
 class TemplateFieldCreator(BaseModel, ABC):
     field_type: str = "str"
@@ -59,6 +61,9 @@ class TemplateFieldCreator(BaseModel, ABC):
     refresh: Optional[bool] = None
     """Specifies if the field should be refreshed. Defaults to False."""
 
+    range_spec: Optional[RangeSpec] = None
+    """Range specification for the field. Defaults to None."""
+
     def to_dict(self):
         result = self.model_dump()
         # Remove key if it is None
@@ -73,6 +78,10 @@ class TemplateFieldCreator(BaseModel, ABC):
 
         if self.field_type == "file":
             result["file_path"] = self.file_path
+
+        # If type is float but range_spec is not set, set it to default
+        if self.field_type == "float" and not self.range_spec:
+            result["range_spec"] = RangeSpec().model_dump()
         return result
 
 

--- a/src/backend/langflow/template/field/base.py
+++ b/src/backend/langflow/template/field/base.py
@@ -61,7 +61,7 @@ class TemplateField(BaseModel):
     refresh: Optional[bool] = None
     """Specifies if the field should be refreshed. Defaults to False."""
 
-    range_spec: Optional[RangeSpec] = None
+    range_spec: Optional[RangeSpec] = Field(None, serialization_alias="rangeSpec")
     """Range specification for the field. Defaults to None."""
 
     def to_dict(self):
@@ -73,8 +73,10 @@ class TemplateField(BaseModel):
             return value
         return ""
 
-    @field_serializer("range_spec")
-    def serialize_range_spec(self, value):
-        if self.field_type == "float" and value is None:
-            return RangeSpec().model_dump()
+    @field_serializer("field_type")
+    def serialize_field_type(self, value, _info):
+        if value == "float":
+            # check if range_spec is set
+            if self.range_spec is None:
+                self.range_spec = RangeSpec()
         return value

--- a/src/frontend/src/CustomNodes/GenericNode/components/parameterComponent/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/parameterComponent/index.tsx
@@ -457,7 +457,7 @@ export default function ParameterComponent({
             <FloatComponent
               disabled={disabled}
               value={data.node?.template[name].value ?? ""}
-              rangeSpec={data.node?.template[name].range_spec}
+              rangeSpec={data.node?.template[name].rangeSpec}
               onChange={handleOnNewValue}
             />
           </div>

--- a/src/frontend/src/CustomNodes/GenericNode/components/parameterComponent/index.tsx
+++ b/src/frontend/src/CustomNodes/GenericNode/components/parameterComponent/index.tsx
@@ -457,6 +457,7 @@ export default function ParameterComponent({
             <FloatComponent
               disabled={disabled}
               value={data.node?.template[name].value ?? ""}
+              rangeSpec={data.node?.template[name].range_spec}
               onChange={handleOnNewValue}
             />
           </div>

--- a/src/frontend/src/components/codeTabsComponent/index.tsx
+++ b/src/frontend/src/components/codeTabsComponent/index.tsx
@@ -472,6 +472,11 @@ export default function CodeTabsComponent({
                                                           templateField
                                                         ].value
                                                   }
+                                                  rangeSpec={
+                                                    node.data.node.template[
+                                                      templateField
+                                                    ].rangeSpec
+                                                  }
                                                   onChange={(target) => {
                                                     setData((old) => {
                                                       let newInputList =

--- a/src/frontend/src/components/floatComponent/index.tsx
+++ b/src/frontend/src/components/floatComponent/index.tsx
@@ -7,11 +7,14 @@ export default function FloatComponent({
   value,
   onChange,
   disabled,
+  rangeSpec,
   editNode = false,
 }: FloatComponentType): JSX.Element {
-  const step = 0.1;
-  const min = -2;
-  const max = 2;
+  const step = rangeSpec?.step ?? 0.1;
+  const min = rangeSpec?.min ?? -2;
+  const max = rangeSpec?.max ?? 2;
+  console.log("FloatComponent", value, disabled, rangeSpec, editNode);
+  console.log("FloatComponent", step, min, max);
 
   // Clear component state
   useEffect(() => {
@@ -40,7 +43,9 @@ export default function FloatComponent({
         disabled={disabled}
         className={editNode ? "input-edit-node" : ""}
         placeholder={
-          editNode ? "Number -2 to 2" : "Type a number from minus two to two"
+          editNode
+            ? `Enter a value between ${min} and ${max}`
+            : `Enter a value between ${min} and ${max}`
         }
         onChange={(event) => {
           onChange(event.target.value);

--- a/src/frontend/src/components/intComponent/index.tsx
+++ b/src/frontend/src/components/intComponent/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { FloatComponentType } from "../../types/components";
+import { IntComponentType } from "../../types/components";
 import { handleKeyDown } from "../../utils/reactflowUtils";
 import { Input } from "../ui/input";
 
@@ -9,7 +9,7 @@ export default function IntComponent({
   disabled,
   editNode = false,
   id = "",
-}: FloatComponentType): JSX.Element {
+}: IntComponentType): JSX.Element {
   const min = 0;
 
   // Clear component state

--- a/src/frontend/src/modals/EditNodeModal/index.tsx
+++ b/src/frontend/src/modals/EditNodeModal/index.tsx
@@ -360,6 +360,10 @@ const EditNodeModal = forwardRef(
                                     <FloatComponent
                                       disabled={disabled}
                                       editNode={true}
+                                      rangeSpec={
+                                        myData.node!.template[templateParam]
+                                          .range_spec
+                                      }
                                       value={
                                         myData.node.template[templateParam]
                                           .value ?? ""

--- a/src/frontend/src/modals/EditNodeModal/index.tsx
+++ b/src/frontend/src/modals/EditNodeModal/index.tsx
@@ -362,7 +362,7 @@ const EditNodeModal = forwardRef(
                                       editNode={true}
                                       rangeSpec={
                                         myData.node!.template[templateParam]
-                                          .range_spec
+                                          .rangeSpec
                                       }
                                       value={
                                         myData.node.template[templateParam]

--- a/src/frontend/src/types/components/index.ts
+++ b/src/frontend/src/types/components/index.ts
@@ -138,10 +138,26 @@ export type DisclosureComponentType = {
     }[];
   };
 };
+
+export type RangeSpecType = {
+  min: number;
+  max: number;
+  step: number;
+};
+
+export type IntComponentType = {
+  value: string;
+  disabled?: boolean;
+  onChange: (value: string) => void;
+  editNode?: boolean;
+  id?: string;
+};
+
 export type FloatComponentType = {
   value: string;
   disabled?: boolean;
   onChange: (value: string) => void;
+  rangeSpec: RangeSpecType;
   editNode?: boolean;
   id?: string;
 };

--- a/tests/test_llms_template.py
+++ b/tests/test_llms_template.py
@@ -84,6 +84,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "range_spec": {"max": 1.0, "min": -1.0, "step": 0.1},
     }
     assert template["max_tokens"] == {
         "required": False,
@@ -112,6 +113,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "range_spec": {"max": 1.0, "min": -1.0, "step": 0.1},
     }
     assert template["frequency_penalty"] == {
         "required": False,
@@ -126,6 +128,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "range_spec": {"max": 1.0, "min": -1.0, "step": 0.1},
     }
     assert template["presence_penalty"] == {
         "required": False,
@@ -140,6 +143,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "range_spec": {"max": 1.0, "min": -1.0, "step": 0.1},
     }
     assert template["n"] == {
         "required": False,
@@ -223,6 +227,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "range_spec": {"max": 1.0, "min": -1.0, "step": 0.1},
     }
     assert template["logit_bias"] == {
         "required": False,
@@ -338,6 +343,7 @@ def test_chat_open_ai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "range_spec": {"max": 1.0, "min": -1.0, "step": 0.1},
     }
     assert template["model_kwargs"] == {
         "required": False,
@@ -379,6 +385,7 @@ def test_chat_open_ai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
+        "range_spec": {"max": 1.0, "min": -1.0, "step": 0.1},
     }
     assert template["max_retries"] == {
         "required": False,

--- a/tests/test_llms_template.py
+++ b/tests/test_llms_template.py
@@ -88,7 +88,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
-        "range_spec": {"max": 1.0, "min": -1.0, "step": 0.1},
+        "rangeSpec": {"max": 1.0, "min": -1.0, "step": 0.1},
         "fileTypes": [],
     }
     assert template["max_tokens"] == {
@@ -119,7 +119,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
-        "range_spec": {"max": 1.0, "min": -1.0, "step": 0.1},
+        "rangeSpec": {"max": 1.0, "min": -1.0, "step": 0.1},
         "fileTypes": [],
     }
     assert template["frequency_penalty"] == {
@@ -135,7 +135,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
-        "range_spec": {"max": 1.0, "min": -1.0, "step": 0.1},
+        "rangeSpec": {"max": 1.0, "min": -1.0, "step": 0.1},
         "fileTypes": [],
     }
     assert template["presence_penalty"] == {
@@ -151,7 +151,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
-        "range_spec": {"max": 1.0, "min": -1.0, "step": 0.1},
+        "rangeSpec": {"max": 1.0, "min": -1.0, "step": 0.1},
         "fileTypes": [],
     }
     assert template["n"] == {
@@ -241,7 +241,7 @@ def test_openai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
-        "range_spec": {"max": 1.0, "min": -1.0, "step": 0.1},
+        "rangeSpec": {"max": 1.0, "min": -1.0, "step": 0.1},
         "fileTypes": [],
     }
     assert template["logit_bias"] == {
@@ -364,7 +364,7 @@ def test_chat_open_ai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
-        "range_spec": {"max": 1.0, "min": -1.0, "step": 0.1},
+        "rangeSpec": {"max": 1.0, "min": -1.0, "step": 0.1},
         "fileTypes": [],
     }
     assert template["model_kwargs"] == {
@@ -409,7 +409,7 @@ def test_chat_open_ai(client: TestClient, logged_in_headers):
         "list": False,
         "advanced": False,
         "info": "",
-        "range_spec": {"max": 1.0, "min": -1.0, "step": 0.1},
+        "rangeSpec": {"max": 1.0, "min": -1.0, "step": 0.1},
         "fileTypes": [],
     }
     assert template["max_retries"] == {


### PR DESCRIPTION
This pull request adds a new class called RangeSpec. The RangeSpec class is used to define a range specification for a field. It has three properties: min, max, and step. The min property specifies the minimum value in the range, the max property specifies the maximum value in the range, and the step property specifies the step size between values in the range. The RangeSpec class also includes validation logic to ensure that the max value is greater than the min value and that the step value is positive. This pull request improves the code by fixing the imports and adding the RangeSpec class.