### PR TITLE
Adding Vectara Self Query Retriever - feature request

### DIFF
--- a/src/backend/langflow/components/retrievers/VectaraSelfQueryRetriever.py
+++ b/src/backend/langflow/components/retrievers/VectaraSelfQueryRetriever.py
@@ -69,5 +69,3 @@ class VectaraSelfQueryRetriverComponent(CustomComponent):
             metadata_field_obj, 
             verbose=True
         )
-    
- 

--- a/src/backend/langflow/components/retrievers/VectaraSelfQueryRetriever.py
+++ b/src/backend/langflow/components/retrievers/VectaraSelfQueryRetriever.py
@@ -8,17 +8,22 @@ from langchain.retrievers.self_query.base import SelfQueryRetriever
 from langchain.chains.query_constructor.base import AttributeInfo
 
 
-class VectaraComponent(CustomComponent):
+class VectaraSelfQueryRetriverComponent(CustomComponent):
+    """
+    A custom component for implementing Vectara Self Query Retriever using a vector store.
+    """
+
     display_name: str = "Vectara Self Query Retriever for Vectara Vector Store"
     description: str = "Implementation of Vectara Self Query Retriever"
     documentation = (
-        "https://python.langchain.com/docs/integrations/vectorstores/vectara"
+        "https://python.langchain.com/docs/integrations/retrievers/self_query/vectara_self_query"
     )
     beta = True
+
     field_config = {
-        "code": {"show": False},
+        "code": {"show": True},
         "vectorstore": {
-            "display_name": "Vectara Vector Store", 
+            "display_name": "Vector Store", 
             "info": "Input Vectara Vectore Store"
             },
         "llm": {
@@ -31,8 +36,8 @@ class VectaraComponent(CustomComponent):
             },
         "metadata_field_info": {
             "display_name": "Metadata Field Info", 
-            "info": "Check dictionary format in documentation for self query retriever",
-            "info": "Each metadata field is a string in the form of json containing additional search metadata.\nExample input: {\"name\":\"speech\",\"description\":\"what name of the speech\",\"type\":\"string or list[string]\"}.\nThe keys should remain constant",
+            # "info": "Check dictionary format in documentation for self query retriever",
+            "info": "Each metadata field info is a string in the form of key value pair dictionary containing additional search metadata.\nExample input: {\"name\":\"speech\",\"description\":\"what name of the speech\",\"type\":\"string or list[string]\"}.\nThe keys should remain constant(name, description, type)",
             },
     }
 

--- a/src/backend/langflow/components/vectorstores/Vectara.py
+++ b/src/backend/langflow/components/vectorstores/Vectara.py
@@ -1,24 +1,13 @@
-<<<<<<< HEAD
-from typing import Optional, Union
-
-from langchain.schema import BaseRetriever, Document
-=======
 from typing import Optional, Union, List
 from langflow import CustomComponent
 import tempfile
 import urllib.request
 import urllib
->>>>>>> 68d6fae606967a7e7ac46ac239dd803d8fde891e
 from langchain.vectorstores import Vectara
 from langchain.vectorstores.base import VectorStore
-<<<<<<< HEAD
-
-from langflow import CustomComponent
-=======
 from langchain.schema import BaseRetriever
 from langchain.schema.vectorstore import VectorStore
 from langchain.embeddings import FakeEmbeddings
->>>>>>> 68d6fae606967a7e7ac46ac239dd803d8fde891e
 
 
 class VectaraComponent(CustomComponent):

--- a/src/backend/langflow/components/vectorstores/Vectara.py
+++ b/src/backend/langflow/components/vectorstores/Vectara.py
@@ -3,10 +3,11 @@ from langflow import CustomComponent
 import tempfile
 import urllib.request
 import urllib
+
 from langchain.vectorstores import Vectara
+from langchain.schema import Document
 from langchain.vectorstores.base import VectorStore
 from langchain.schema import BaseRetriever
-from langchain.schema.vectorstore import VectorStore
 from langchain.embeddings import FakeEmbeddings
 
 


### PR DESCRIPTION
### Pull Request for Issue #1246

**Description**
This pull request addresses issue #1246, which proposes the addition of a self-query retriever according to the LangChain Vectara integration. The self-query retriever aims to empower users with the ability to perform queries directly within the Vectara component(vector store).

**Changes Made**
I have added one more file under `src\backend\langflow\components\retrievers` which contains a new VectaraSelfQueryRetriverComponent class

**Files Added:**  VectaraSelfQueryRetriever.py

**langchain documentation for this component:**
https://python.langchain.com/docs/integrations/retrievers/self_query/vectara_self_query