### PR TITLE
Fix AgentInitializer to has last statement of returning base class

### DIFF
--- a/src/backend/langflow/components/agents/AgentInitializer.py
+++ b/src/backend/langflow/components/agents/AgentInitializer.py
@@ -41,12 +41,11 @@ class AgentInitializerComponent(CustomComponent):
                 handle_parsing_errors=True,
                 max_iterations=max_iterations,
             )
-        else:
-            return initialize_agent(
-                tools=tools,
-                llm=llm,
-                agent=agent,
-                return_intermediate_steps=True,
-                handle_parsing_errors=True,
-                max_iterations=max_iterations,
-            )
+        return initialize_agent(
+            tools=tools,
+            llm=llm,
+            agent=agent,
+            return_intermediate_steps=True,
+            handle_parsing_errors=True,
+            max_iterations=max_iterations,
+        )


### PR DESCRIPTION
From the last update, AgentInitializer lost ability to chain another AgentInitializer via tool.
Fix issue: https://github.com/logspace-ai/langflow/issues/1255