### PR TITLE
Bump version to 0.6.5a0 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langflow"
-version = "0.6.4"
+version = "0.6.5a0"
 description = "A Python package with a built-in web application"
 authors = ["Logspace <contact@logspace.ai>"]
 maintainers = [


### PR DESCRIPTION
This pull request updates the version in the pyproject.toml file to 0.6.5a0.