### PR TITLE
Fix: Error: cannot import name 'CreateTrace' from 'langfuse.callback'

### DIFF
--- a/src/backend/langflow/processing/base.py
+++ b/src/backend/langflow/processing/base.py
@@ -28,13 +28,12 @@ def setup_callbacks(sync, trace_id, **kwargs):
 
 def get_langfuse_callback(trace_id):
     from langflow.services.deps import get_plugins_service
-    from langfuse.callback import CreateTrace
 
     logger.debug("Initializing langfuse callback")
     if langfuse := get_plugins_service().get("langfuse"):
         logger.debug("Langfuse credentials found")
         try:
-            trace = langfuse.trace(CreateTrace(name="langflow-" + trace_id, id=trace_id))
+            trace = langfuse.trace(name="langflow-" + trace_id, id=trace_id)
             return trace.getNewHandler()
         except Exception as exc:
             logger.error(f"Error initializing langfuse callback: {exc}")

--- a/src/backend/langflow/services/plugins/langfuse_plugin.py
+++ b/src/backend/langflow/services/plugins/langfuse_plugin.py
@@ -64,14 +64,13 @@ class LangfusePlugin(CallbackPlugin):
     def get_callback(self, _id: Optional[str] = None):
         if _id is None:
             _id = "default"
-        from langfuse.callback import CreateTrace  # type: ignore
 
         logger.debug("Initializing langfuse callback")
 
         try:
             langfuse_instance = self.get()
             if langfuse_instance is not None and hasattr(langfuse_instance, "trace"):
-                trace = langfuse_instance.trace(CreateTrace(name="langflow-" + _id, id=_id))
+                trace = langfuse_instance.trace(name="langflow-" + _id, id=_id)
                 if trace:
                     return trace.getNewHandler()
 


### PR DESCRIPTION
Fix: 
Error: cannot import name 'CreateTrace' from 'langfuse.callback'

Remove imports of CreateTrace (deprecated in the langfuse 2.x)