### PR TITLE
Add field_order property to CustomComponent

### DIFF
--- a/docs/docs/components/custom.mdx
+++ b/docs/docs/components/custom.mdx
@@ -94,7 +94,8 @@ The CustomComponent class serves as the foundation for creating custom component
 
   | Attribute Name | Description                                                                   |
   | -------------- | ----------------------------------------------------------------------------- |
-  | _`repr_value`_ | Displays the value it receives in the _`build`_ method. Useful for debugging. |
+  | _`status`_ | Displays the value it receives in the _`build`_ method. Useful for debugging. |
+  | _`field_order`_ | Defines the order the fields will be displayed in the canvas.                  |
 
   <Admonition type="info" label="Tip">
 

--- a/src/backend/langflow/interface/custom/custom_component/custom_component.py
+++ b/src/backend/langflow/interface/custom/custom_component/custom_component.py
@@ -27,7 +27,7 @@ class CustomComponent(Component):
     """The code of the component. Defaults to None."""
     field_config: dict = {}
     """The field configuration of the component. Defaults to an empty dictionary."""
-    field_order: List[str] = []
+    field_order: Optional[List[str]] = None
     """The field order of the component. Defaults to an empty list."""
     code_class_base_inheritance: ClassVar[str] = "CustomComponent"
     function_entrypoint_name: ClassVar[str] = "build"
@@ -41,6 +41,9 @@ class CustomComponent(Component):
     def __init__(self, **data):
         self.cache = TTLCache(maxsize=1024, ttl=60)
         super().__init__(**data)
+
+    def _get_field_order(self):
+        return self.field_order or list(self.field_config.keys())
 
     def custom_repr(self):
         if self.repr_value == "":

--- a/src/backend/langflow/interface/custom/custom_component/custom_component.py
+++ b/src/backend/langflow/interface/custom/custom_component/custom_component.py
@@ -5,7 +5,6 @@ from uuid import UUID
 import yaml
 from cachetools import TTLCache, cachedmethod
 from fastapi import HTTPException
-
 from langflow.interface.custom.code_parser.utils import (
     extract_inner_type_from_generic_alias,
     extract_union_types_from_generic_alias,
@@ -28,6 +27,8 @@ class CustomComponent(Component):
     """The code of the component. Defaults to None."""
     field_config: dict = {}
     """The field configuration of the component. Defaults to an empty dictionary."""
+    field_order: List[str] = []
+    """The field order of the component. Defaults to an empty list."""
     code_class_base_inheritance: ClassVar[str] = "CustomComponent"
     function_entrypoint_name: ClassVar[str] = "build"
     function: Optional[Callable] = None

--- a/src/backend/langflow/template/template/base.py
+++ b/src/backend/langflow/template/template/base.py
@@ -9,6 +9,7 @@ from langflow.utils.constants import DIRECT_TYPES
 class Template(BaseModel):
     type_name: str
     fields: list[TemplateField]
+    field_order: list[str] = []
 
     def process_fields(
         self,

--- a/src/backend/langflow/template/template/base.py
+++ b/src/backend/langflow/template/template/base.py
@@ -1,9 +1,8 @@
 from typing import Callable, Union
 
-from pydantic import BaseModel, model_serializer
-
 from langflow.template.field.base import TemplateField
 from langflow.utils.constants import DIRECT_TYPES
+from pydantic import BaseModel, model_serializer
 
 
 class Template(BaseModel):
@@ -31,6 +30,7 @@ class Template(BaseModel):
         for field in self.fields:
             result[field.name] = field.model_dump(by_alias=True, exclude_none=True)
         result["_type"] = result.pop("type_name")
+        result.pop("field_order", None)
         return result
 
     # For backwards compatibility


### PR DESCRIPTION
This pull request adds a new property called `field_order` to the `CustomComponent` class. The `field_order` property allows developers to define the order in which fields will be displayed in the canvas. This can be useful for customizing the layout of the component.

#1373