### PR TITLE
Fix broken link in prompts.mdx

### DIFF
--- a/docs/docs/components/prompts.mdx
+++ b/docs/docs/components/prompts.mdx
@@ -21,7 +21,7 @@ The `PromptTemplate` component allows users to create prompts and define variabl
 <Admonition type="info">
   Once a variable is defined in the prompt template, it becomes a component
   input of its own. Check out [Prompt
-  Customization](../guidelines/prompt-customization.mdx) to learn more.
+  Customization](../docs/guidelines/prompt-customization.mdx) to learn more.
 </Admonition>
 
 - **template:** Template used to format an individual request.


### PR DESCRIPTION
This pull request fixes a broken link in the prompts.mdx file. The link to the "Prompt Customization" page was pointing to the wrong location. This PR updates the link to the correct location in the documentation.