### PR TITLE
Bugfix: Refresh Token Renovation

### DIFF
--- a/src/backend/langflow/api/v1/login.py
+++ b/src/backend/langflow/api/v1/login.py
@@ -98,7 +98,7 @@ async def refresh_token(request: Request, response: Response, settings_service=D
         response.set_cookie(
             "refresh_token_lf",
             tokens["refresh_token"],
-            httponly=auth_settings.REFRESH_TOKEN_HTTPONLY,
+            httponly=auth_settings.REFRESH_HTTPONLY,
             samesite=auth_settings.REFRESH_SAME_SITE,
             secure=auth_settings.REFRESH_SECURE,
             expires=auth_settings.REFRESH_TOKEN_EXPIRE_MINUTES * 60,

--- a/src/frontend/src/pages/StorePage/index.tsx
+++ b/src/frontend/src/pages/StorePage/index.tsx
@@ -147,7 +147,7 @@ export default function StorePage(): JSX.Element {
         }
       })
       .catch((err) => {
-        if (err.response.status === 403 || err.response.status === 401) {
+        if (err.response?.status === 403 || err.response?.status === 401) {
           setValidApiKey(false);
         } else {
           setSearchData([]);


### PR DESCRIPTION
This pull request addresses a critical issue where the refresh token renovation process fails when it expires. Currently, when the refresh token reaches its expiration, the system fails to properly renew it, causing authentication failures for users and disrupting service continuity.