### PR TITLE
Title: Bugfix: Resolve Login Loop for Incorrect Username or Password

### DIFF
--- a/src/backend/langflow/services/settings/auth.py
+++ b/src/backend/langflow/services/settings/auth.py
@@ -22,7 +22,7 @@ class AuthSettings(BaseSettings):
         frozen=False,
     )
     ALGORITHM: str = "HS256"
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 1
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
     REFRESH_TOKEN_EXPIRE_MINUTES: int = 60 * 12 * 7
 
     # API Key to execute /process endpoint

--- a/src/backend/langflow/services/settings/auth.py
+++ b/src/backend/langflow/services/settings/auth.py
@@ -22,7 +22,7 @@ class AuthSettings(BaseSettings):
         frozen=False,
     )
     ALGORITHM: str = "HS256"
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 1
     REFRESH_TOKEN_EXPIRE_MINUTES: int = 60 * 12 * 7
 
     # API Key to execute /process endpoint

--- a/src/frontend/src/controllers/API/api.tsx
+++ b/src/frontend/src/controllers/API/api.tsx
@@ -107,6 +107,7 @@ function ApiInterceptor() {
 
   async function tryToRenewAccessToken(error: AxiosError) {
     try {
+      if (window.location.pathname.includes("/login")) return;
       const res = await renewAccessToken();
       if (res?.data?.access_token && res?.data?.refresh_token) {
         login(res?.data?.access_token);


### PR DESCRIPTION
This pull request addresses a critical bug where the login process enters into a loop when users provide incorrect credentials, specifically when the username or password is invalid. Prior to this fix, the system would repeatedly prompt users to re-enter their credentials without providing any indication of the error, leading to frustration and confusion among users.

