### PR TITLE
Fix unintended input submission during IME composition

### DIFF
--- a/src/frontend/src/modals/formModal/chatInput/index.tsx
+++ b/src/frontend/src/modals/formModal/chatInput/index.tsx
@@ -29,7 +29,7 @@ export default function ChatInput({
     <div className="relative">
       <Textarea
         onKeyDown={(event) => {
-          if (event.key === "Enter" && !lockChat && !event.shiftKey) {
+          if (event.key === "Enter" && !event.nativeEvent.isComposing && !lockChat && !event.shiftKey) {
             sendMessage();
           }
         }}


### PR DESCRIPTION
This pull request addresses an issue where pressing the Enter key during IME (Input Method Editor) composition unintentionally submits the input content.

## Problem
In the current implementation, when users input text using an IME for languages like Japanese, pressing the Enter key during composition submits the input before the conversion is finalized. This behavior causes frustration for users, as they unintentionally submit the input each time they press Enter to confirm the conversion.

## Solution
Added `!event.nativeEvent.isComposing` to the condition alongside `event.key === "Enter"`