### PR TITLE
Fix CSS on Chat Border when have overflow of variables

### DIFF
--- a/src/frontend/src/components/IOview/index.tsx
+++ b/src/frontend/src/components/IOview/index.tsx
@@ -129,7 +129,7 @@ export default function IOView({
         </div>
       </BaseModal.Header>
       <BaseModal.Content>
-        <div className="flex h-full flex-col overflow-hidden">
+        <div className="flex h-full flex-col ">
           <div className="flex-max-width mt-2 h-full">
             {selectedTab !== 0 && (
               <div


### PR DESCRIPTION
♻️ (IOview/index.tsx): remove unnecessary 'overflow-hidden' class from IOView component to fix layout issue