### PR TITLE
Changes to README for virtualenv information to ensure Python 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@
 
 Make sure you have **Python 3.10** installed on your system.
 
+On Mac + Virtualenv: 
+```shell
+brew install python@3.10
+virtualenv -p /usr/bin/python3.10 langflow
+source langflow/bin/activate
+```
+
+With Anaconda:
+```shell
+conda create -n langflow python=3.10
+conda activate langflow
+```
+
 You can install Langflow with pip:
 
 ```shell


### PR DESCRIPTION
Got caught a few times not using the exact version of Python required. Thought this would help new users. 