### PR TITLE
Add version check before publishing to PyPI

### DIFF
--- a/.github/workflows/pre-release-base.yml
+++ b/.github/workflows/pre-release-base.yml
@@ -35,8 +35,27 @@ jobs:
         run: make build base=true
       - name: Check Version
         id: check-version
+        # In this step, we should check the version of the package
+        # and see if it is a version that is already released
+        # echo version=$(cd src/backend/base && poetry version --short) >> $GITHUB_OUTPUT
+        # cd src/backend/base && poetry version --short should
+        # be different than the last release version in pypi
+        # which we can get from curl -s "https://pypi.org/pypi/langflow/json" | jq -r '.releases | keys | .[]' | sort -V | tail -n 1
         run: |
-          echo version=$(cd src/backend/base && poetry version --short) >> $GITHUB_OUTPUT
+          version=$(cd src/backend/base && poetry version --short)
+          last_released_version=$(curl -s "https://pypi.org/pypi/langflow-base/json" | jq -r '.releases | keys | .[]' | sort -V | tail -n 1)
+          if [ "$version" = "$last_released_version" ]; then
+            echo "Version $version is already released. Skipping release."
+            exit 1
+          else
+            echo version=$version >> $GITHUB_OUTPUT
+          fi
+
+      - name: Publish to PyPI
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          make publish base=true
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
@@ -47,11 +66,6 @@ jobs:
           prerelease: true
           tag: v${{ steps.check-version.outputs.version }}
           commit: dev
-      - name: Publish to PyPI
-        env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          make publish base=true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/pre-release-langflow.yml
+++ b/.github/workflows/pre-release-langflow.yml
@@ -40,9 +40,21 @@ jobs:
       - name: Check Version
         id: check-version
         run: |
-          echo version=$(poetry version --short) >> $GITHUB_OUTPUT
+          version=$(cd src/backend/base && poetry version --short)
+          last_released_version=$(curl -s "https://pypi.org/pypi/langflow/json" | jq -r '.releases | keys | .[]' | sort -V | tail -n 1)
+          if [ "$version" = "$last_released_version" ]; then
+            echo "Version $version is already released. Skipping release."
+            exit 1
+          else
+            echo version=$version >> $GITHUB_OUTPUT
+          fi
       - name: Display pyproject.toml langflow-base Version
         run: cat pyproject.toml | grep langflow-base
+      - name: Publish to PyPI
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          make publish main=true
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
@@ -53,11 +65,6 @@ jobs:
           prerelease: true
           tag: v${{ steps.check-version.outputs.version }}
           commit: dev
-      - name: Publish to PyPI
-        env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          make publish main=true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx


### PR DESCRIPTION
This pull request adds a version check before publishing to PyPI. It ensures that the version of the package being published is not already released. If the version is already released, the release process is skipped. This helps prevent accidental re-releases of the same version.